### PR TITLE
Add Mini-Tools.uk Image Color Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [HyperColor](https://hypercolor.dev) - A curated collection of beautiful Tailwind CSS gradients using the full range of Tailwind CSS colors.
 - [Color Hunt](https://colorhunt.co) - Color palettes for designers and artists.
 - [Color Lisa](https://colorlisa.com) - Color palette masterpieces from the world's greatest artists.
+- [Mini-Tools.uk Image Color Picker](https://mini-tools.uk/color-picker) - Pick colors from images or screenshots, crop small areas, and copy HEX, RGB or HSL values.
 - [Brand Colors](https://brandcolors.net) - The biggest collection of official brand color codes around.
 - [The day's color](https://www.thedayscolor.com) - The daily color digest.
 - [Color Drop](https://colordrop.io) - Color palette tool built for creatives to help get inspiration for designs or projects they're working on.


### PR DESCRIPTION
Hi, I'd like to add Mini-Tools.uk Image Color Picker to the Colors section.

Self-recommendation: I built and use this small color picker myself. It is for a workflow I run into often: grabbing an exact color from a screenshot, mockup, product image, or UI reference without opening a full design app.

The workflow is intentionally simple: open an image, crop a small area if needed, pick a color, and copy the HEX/RGB/HSL value.