### PR TITLE
Add 21 curated design resources across all six language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -37,6 +37,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Chakra UI](https://chakra-ui.com) - Eine einfache, modulare und barrierefreie Komponentenbibliothek für React-Anwendungen.
 - [HeroUI](https://www.heroui.com) - Schöne, schnelle und moderne React UI-Bibliothek mit TypeScript-Unterstützung und integriertem Dark Mode.
 - [Untitled UI](https://www.untitledui.com/react) - Die weltweit größte Open-Source-Sammlung von React-Komponenten, gebaut mit Tailwind CSS und React Aria für pixelgenaue, barrierefreie Oberflächen.
+- [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
+- [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
+- [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
 
 ## Icons
 
@@ -52,6 +55,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Isocons](https://www.isocons.app) - Isometrische Icons für Ihre Produkte, Projekte, Poster und Präsentationen.
 - [lucide-animated](https://lucide-animated.com) - Schön gestaltete animierte Icons.
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Eine Sammlung von macOS-Icons.
+- [Hugeicons](https://hugeicons.com) - Über 59.000 Icons in mehreren Stilen, mit kostenlosem Basis-Set und Pro-Bibliothek für größere Projekte.
+- [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
 
@@ -62,6 +67,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [vectorCraftr](https://vectorcraftr.com) - Alle Illustrationen sind kostenlos für kommerzielle Nutzung.
 - [unDraw](https://undraw.co) - Open-Source-Illustrationen für jede Idee, die Sie sich vorstellen und erstellen können.
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - Die Internet-Quelle für Visuals. Angetrieben von Creators überall.
+- [Absurd Design](https://absurd.design) - Surreale, handgezeichnete Illustrationsserien mit unverwechselbarem Stil, kostenlos für private und kommerzielle Nutzung.
+- [Humaaans](https://www.humaaans.com) - Kombinierbare Personen-Illustrationen zum Neuzusammenstellen und Umfärben, veröffentlicht unter CC0.
 - [DrawKit](https://www.drawkit.com) - 💵 Handgezeichnete 2D & 3D Illustrationen, Icons und Animationen. Perfekt für Ihr nächstes Projekt. Alles an einem Ort.
 - [Storyset](https://storyset.com) - Großartige kostenlose anpassbare Illustrationen für Ihr nächstes Projekt.
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
@@ -86,6 +93,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [BARNIMAGES](https://barnimages.com) - Kostenlose hochauflösende Bilder für alle.
 - [Little Visuals](https://littlevisuals.co) - Kostenlose, hochauflösende Bilder. Verwenden Sie sie, wie Sie wollen - kostenlos für kommerzielle Nutzung.
 - [UI Faces](https://uifaces.co) - Kostenlose KI-generierte Avatare für Ihre kreativen Projekte.
+- [Nappy](https://nappy.co) - Schöne hochauflösende Fotos von Schwarzen und Brown People, kostenlos für private und kommerzielle Nutzung.
 - [Deposit Photos](https://depositphotos.com) - 💵 Lizenzfreie Stock-Fotos, Vektorbilder, Videos und Musik.
 - [Freepik](https://www.freepik.com) - 💵 Millionen kostenloser Vektoren, PSD-Dateien, Fotos und KI-generierter Bilder. Premium-Ressourcen für Ihre kreativen Projekte.
 
@@ -93,10 +101,13 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 
 - [Google Fonts](https://fonts.google.com) - Eine Bibliothek von über 1000 kostenlosen lizenzierten Schriftfamilien und APIs für bequeme Nutzung über CSS und Android.
 - [Inter](https://rsms.me/inter/) - Eine variable Schriftfamilie für Text-Benutzeroberflächen.
+- [Fontshare](https://www.fontshare.com) - Ein kostenloser Font-Dienst der Indian Type Foundry mit hochwertigen Schriften für private und kommerzielle Nutzung.
+- [Uncut](https://uncut.wtf) - Eine kuratierte Bibliothek zeitgenössischer Open-Source-Schriften, kostenlos zum Herunterladen und Verwenden.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Kaufen Sie kuratierte Qualitätsprodukte und Waren.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
 - [Klim](https://klim.co.nz) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
+- [Pangram Pangram](https://pangrampangram.com) - 💵 Eine unabhängige Schriftgießerei mit hochwertigen Schriften, kostenlos testbar vor dem Lizenzkauf.
 
 ## Farben
 
@@ -110,6 +121,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [The day's color](https://www.thedayscolor.com) - Der tägliche Farb-Digest.
 - [Color Drop](https://colordrop.io) - Farbpaletten-Tool für Kreative, um Inspiration für Designs oder Projekte zu erhalten, an denen sie arbeiten.
 - [Realtime Colors](https://www.realtimecolors.com) - Sehen Sie Ihre Farbpalette und Schriftwahl live auf einer echten Website-Oberfläche, mit sofortiger Kontrastprüfung und CSS/Tailwind-Export.
+- [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
+- [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
+- [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
 
 ## Werkzeuge
 
@@ -118,6 +132,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Rive](https://rive.app) - Ein neuer Weg, Benutzeroberflächen zu entwerfen, zu erstellen und zu versenden.
 - [Lottielab](https://www.lottielab.com) - Das Motion-Design-Tool für Produktteams.
 - [Notion Avatar Maker](https://notion-avatar.app) - Erstellen von Notion-Style-Avataren.
+- [Haikei](https://haikei.app) - Erzeuge einzigartige SVG-Hintergründe, Blobs, Wellen und weitere Design-Assets direkt im Browser.
+- [ray.so](https://ray.so) - Verwandelt Code-Snippets in schöne, teilbare Bilder – von den Machern von Raycast.
+- [tldraw](https://www.tldraw.com) - Ein kollaboratives, unendliches Whiteboard zum Skizzieren von Diagrammen, Wireframes und Ideen.
 - [Rotato](https://rotato.app) - 💵 3D-Mockup-Bilder und Filme in Minuten.
 - [Spline](https://spline.design) - 💵 Ein Ort zum Entwerfen und Zusammenarbeiten in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
@@ -126,10 +143,12 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Sketch](https://www.sketch.com) - 💵 Ein Toolkit von Designern für Designer, das den Fokus auf Sie und Ihre Arbeit legt.
 - [Canva](https://www.canva.com) - 💵 Erstellen Sie mühelos atemberaubende Designs mit Canvas Drag & Drop-Funktion und professionellen Layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digitale Produktdesign-Plattform für die weltbesten Benutzererfahrungen.
+- [Screen Studio](https://screen.studio) - 💵 macOS-Bildschirmrekorder mit automatischem Zoom und weichen Animationen für polierte Produkt-Demos.
 
 ## Bücher
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
+- [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
 
 ## Communities
@@ -138,3 +157,5 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Uiverse](https://uiverse.io) - Community-erstellte Bibliothek von UI-Elementen. Kopieren als HTML/CSS, Tailwind, React und Figma.
 - [Sketchfab](https://sketchfab.com) - Sketchfab ist eine 3D-Asset-Website zum Veröffentlichen, Teilen, Entdecken, Kaufen und Verkaufen von 3D-, VR- und AR-Inhalten.
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
+- [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
+- [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.

--- a/README.es.md
+++ b/README.es.md
@@ -37,6 +37,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Chakra UI](https://chakra-ui.com) - Una librería de componentes simple, modular y accesible para aplicaciones React.
 - [HeroUI](https://www.heroui.com) - Librería UI React hermosa, rápida y moderna con soporte TypeScript y modo oscuro incorporado.
 - [Untitled UI](https://www.untitledui.com/react) - La colección de componentes React de código abierto más grande del mundo, construida con Tailwind CSS y React Aria para interfaces perfectas y accesibles.
+- [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
+- [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
+- [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
 
 ## Iconos
 
@@ -52,6 +55,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Isocons](https://www.isocons.app) - Iconos isométricos para tus productos, proyectos, pósters y presentaciones.
 - [lucide-animated](https://lucide-animated.com) - Iconos animados hermosamente elaborados.
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Una colección de iconos de macOS.
+- [Hugeicons](https://hugeicons.com) - Más de 59.000 iconos en múltiples estilos, con un set básico gratuito y una biblioteca pro para proyectos mayores.
+- [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
 
@@ -62,6 +67,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [vectorCraftr](https://vectorcraftr.com) - Todas las ilustraciones son gratuitas para uso comercial.
 - [unDraw](https://undraw.co) - Ilustraciones de código abierto para cualquier idea que puedas imaginar y crear.
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - La fuente de visuales del internet. Impulsado por creadores de todas partes.
+- [Absurd Design](https://absurd.design) - Series de ilustraciones surrealistas dibujadas a mano con un estilo distintivo, gratis para uso personal y comercial.
+- [Humaaans](https://www.humaaans.com) - Ilustraciones de personas combinables y recoloreables, publicadas bajo CC0.
 - [DrawKit](https://www.drawkit.com) - 💵 Ilustraciones, iconos y animaciones dibujadas a mano en 2D y 3D. Perfectas para tu próximo proyecto. Todo en un lugar.
 - [Storyset](https://storyset.com) - Increíbles ilustraciones personalizables gratuitas para tu próximo proyecto.
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
@@ -86,6 +93,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [BARNIMAGES](https://barnimages.com) - Imágenes gratuitas de alta resolución para todos.
 - [Little Visuals](https://littlevisuals.co) - Imágenes gratuitas de alta resolución. Úsalas como quieras - gratis para uso comercial.
 - [UI Faces](https://uifaces.co) - Avatares gratuitos generados por IA para tus proyectos creativos.
+- [Nappy](https://nappy.co) - Hermosas fotos en alta resolución de personas negras y morenas, gratis para uso personal y comercial.
 - [Deposit Photos](https://depositphotos.com) - 💵 Fotos de stock libres de derechos, imágenes vectoriales, videos y música.
 - [Freepik](https://www.freepik.com) - 💵 Millones de vectores gratuitos, archivos PSD, fotos e imágenes generadas por IA. Recursos premium para tus proyectos creativos.
 
@@ -93,10 +101,13 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 
 - [Google Fonts](https://fonts.google.com) - Una librería de más de 1,000 familias de fuentes con licencia gratuita y APIs para uso conveniente vía CSS y Android.
 - [Inter](https://rsms.me/inter/) - Una familia de fuentes variable para interfaces de texto.
+- [Fontshare](https://www.fontshare.com) - Un servicio de fuentes gratuito de Indian Type Foundry, con tipografías de calidad licenciadas para uso personal y comercial.
+- [Uncut](https://uncut.wtf) - Una biblioteca curada de tipografías contemporáneas de código abierto, gratis para descargar y usar.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Compra productos y bienes de calidad y curados.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
 - [Klim](https://klim.co.nz) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
+- [Pangram Pangram](https://pangrampangram.com) - 💵 Una fundición tipográfica independiente con tipografías de alta calidad, gratis para probar antes de licenciarlas.
 
 ## Colores
 
@@ -110,6 +121,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [The day's color](https://www.thedayscolor.com) - El resumen diario de colores.
 - [Color Drop](https://colordrop.io) - Herramienta de paleta de colores construida para creativos para ayudar a obtener inspiración para diseños o proyectos en los que están trabajando.
 - [Realtime Colors](https://www.realtimecolors.com) - Previsualiza tu paleta de colores y tipografía en vivo sobre la interfaz de un sitio web real, con verificación instantánea de contraste y exportación a CSS/Tailwind.
+- [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
+- [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
+- [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
 
 ## Herramientas
 
@@ -118,6 +132,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Rive](https://rive.app) - Una nueva forma de diseñar, construir y enviar interfaces de usuario.
 - [Lottielab](https://www.lottielab.com) - La herramienta de diseño de movimiento para equipos de producto.
 - [Notion Avatar Maker](https://notion-avatar.app) - Creando avatares estilo Notion.
+- [Haikei](https://haikei.app) - Genera fondos SVG únicos, blobs, ondas y otros recursos de diseño directamente en el navegador.
+- [ray.so](https://ray.so) - Convierte fragmentos de código en imágenes bonitas listas para compartir, de los creadores de Raycast.
+- [tldraw](https://www.tldraw.com) - Una pizarra infinita colaborativa para bocetar diagramas, wireframes e ideas.
 - [Rotato](https://rotato.app) - 💵 Imágenes mockup 3D y películas en minutos.
 - [Spline](https://spline.design) - 💵 Un lugar para diseñar y colaborar en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
@@ -126,10 +143,12 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Sketch](https://www.sketch.com) - 💵 Un kit de herramientas hecho por diseñadores, para diseñadores, que pone el foco en ti y tu trabajo.
 - [Canva](https://www.canva.com) - 💵 Crea diseños impresionantes fácilmente con la función de arrastrar y soltar de Canva y diseños profesionales.
 - [InVision](https://www.invisionapp.com) - 💵 Plataforma de diseño de productos digitales que impulsa las mejores experiencias de usuario del mundo.
+- [Screen Studio](https://screen.studio) - 💵 Grabador de pantalla para macOS con zoom automático y animaciones suaves para demos de producto pulidas.
 
 ## Libros
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
+- [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
 
 ## Comunidades
@@ -138,3 +157,5 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Uiverse](https://uiverse.io) - Librería de elementos UI construida por la comunidad. Copia como HTML/CSS, Tailwind, React y Figma.
 - [Sketchfab](https://sketchfab.com) - Sketchfab es un sitio web de recursos 3D usado para publicar, compartir, descubrir, comprar y vender contenido 3D, VR y AR.
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
+- [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
+- [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.

--- a/README.fr.md
+++ b/README.fr.md
@@ -37,6 +37,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Chakra UI](https://chakra-ui.com) - Une bibliothèque de composants simple, modulaire et accessible pour les applications React.
 - [HeroUI](https://www.heroui.com) - Bibliothèque UI React belle, rapide et moderne avec support TypeScript et mode sombre intégré.
 - [Untitled UI](https://www.untitledui.com/react) - La plus grande collection open source de composants React au monde, construite avec Tailwind CSS et React Aria pour des interfaces accessibles et parfaitement soignées.
+- [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
+- [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
+- [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
 
 ## Icônes
 
@@ -52,6 +55,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Isocons](https://www.isocons.app) - Icônes isométriques pour vos produits, projets, affiches et présentations.
 - [lucide-animated](https://lucide-animated.com) - Icônes animées magnifiquement conçues.
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Une collection d'icônes macOS.
+- [Hugeicons](https://hugeicons.com) - Plus de 59 000 icônes en plusieurs styles, avec un jeu de base gratuit et une bibliothèque pro pour les projets plus ambitieux.
+- [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
 
@@ -62,6 +67,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [vectorCraftr](https://vectorcraftr.com) - Toutes les illustrations sont gratuites pour usage commercial.
 - [unDraw](https://undraw.co) - Illustrations open source pour toute idée que vous pouvez imaginer et créer.
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - La source internet pour les visuels. Alimentée par des créateurs de partout.
+- [Absurd Design](https://absurd.design) - Séries d'illustrations surréalistes dessinées à la main au style singulier, gratuites pour un usage personnel et commercial.
+- [Humaaans](https://www.humaaans.com) - Illustrations de personnages à combiner et recolorer librement, publiées sous licence CC0.
 - [DrawKit](https://www.drawkit.com) - 💵 Illustrations, icônes et animations 2D et 3D dessinées à la main. Parfaites pour votre prochain projet. Tout en un lieu.
 - [Storyset](https://storyset.com) - Formidables illustrations personnalisables gratuites pour votre prochain projet.
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
@@ -86,6 +93,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [BARNIMAGES](https://barnimages.com) - Images gratuites haute résolution pour tous.
 - [Little Visuals](https://littlevisuals.co) - Images gratuites, haute résolution. Utilisez-les comme vous voulez - gratuit pour usage commercial.
 - [UI Faces](https://uifaces.co) - Avatars gratuits générés par IA pour vos projets créatifs.
+- [Nappy](https://nappy.co) - De belles photos haute résolution de personnes noires et métisses, gratuites pour un usage personnel et commercial.
 - [Deposit Photos](https://depositphotos.com) - 💵 Photos stock libres de droits, images vectorielles, vidéos et musique.
 - [Freepik](https://www.freepik.com) - 💵 Millions de vecteurs gratuits, fichiers PSD, photos et images générées par IA. Ressources premium pour vos projets créatifs.
 
@@ -93,10 +101,13 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 
 - [Google Fonts](https://fonts.google.com) - Une bibliothèque de plus de 1000 familles de polices sous licence gratuite et APIs pour usage pratique via CSS et Android.
 - [Inter](https://rsms.me/inter/) - Une famille de polices variable pour interfaces texte.
+- [Fontshare](https://www.fontshare.com) - Un service de polices gratuit de l'Indian Type Foundry, avec des typographies de qualité sous licence personnelle et commerciale.
+- [Uncut](https://uncut.wtf) - Une bibliothèque sélectionnée de typographies contemporaines open source, libres de téléchargement et d'utilisation.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Achetez des produits et biens de qualité, sélectionnés.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
 - [Klim](https://klim.co.nz) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
+- [Pangram Pangram](https://pangrampangram.com) - 💵 Une fonderie typographique indépendante aux caractères de haute qualité, gratuits à essayer avant l'achat de licence.
 
 ## Couleurs
 
@@ -110,6 +121,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [The day's color](https://www.thedayscolor.com) - Le digest quotidien des couleurs.
 - [Color Drop](https://colordrop.io) - Outil de palette de couleurs conçu pour les créatifs pour aider à obtenir de l'inspiration pour les designs ou projets sur lesquels ils travaillent.
 - [Realtime Colors](https://www.realtimecolors.com) - Prévisualisez votre palette de couleurs et vos polices en direct sur une véritable interface de site web, avec vérification instantanée du contraste et export CSS/Tailwind.
+- [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
+- [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
+- [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
 
 ## Outils
 
@@ -118,6 +132,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Rive](https://rive.app) - Une nouvelle façon de concevoir, construire et expédier des interfaces utilisateur.
 - [Lottielab](https://www.lottielab.com) - L'outil de design de mouvement pour équipes produit.
 - [Notion Avatar Maker](https://notion-avatar.app) - Création d'avatars style Notion.
+- [Haikei](https://haikei.app) - Générez des arrière-plans SVG uniques, blobs, vagues et autres ressources de design directement dans le navigateur.
+- [ray.so](https://ray.so) - Transformez des extraits de code en belles images prêtes à partager, par les créateurs de Raycast.
+- [tldraw](https://www.tldraw.com) - Un tableau blanc infini et collaboratif pour esquisser diagrammes, wireframes et idées.
 - [Rotato](https://rotato.app) - 💵 Images de maquette 3D et films en minutes.
 - [Spline](https://spline.design) - 💵 Un lieu pour concevoir et collaborer en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
@@ -126,10 +143,12 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Sketch](https://www.sketch.com) - 💵 Une boîte à outils faite par des designers, pour des designers, qui met l'accent sur vous et votre travail.
 - [Canva](https://www.canva.com) - 💵 Créez facilement des designs époustouflants avec la fonction glisser-déposer de Canva et des mises en page professionnelles.
 - [InVision](https://www.invisionapp.com) - 💵 Plateforme de design de produit numérique alimentant les meilleures expériences utilisateur du monde.
+- [Screen Studio](https://screen.studio) - 💵 Enregistreur d'écran macOS avec zoom automatique et animations fluides pour des démos produit soignées.
 
 ## Livres
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
+- [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
 
 ## Communautés
@@ -138,3 +157,5 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Uiverse](https://uiverse.io) - Bibliothèque d'éléments UI construite par la communauté. Copiez en HTML/CSS, Tailwind, React et Figma.
 - [Sketchfab](https://sketchfab.com) - Sketchfab est un site web d'actifs 3D utilisé pour publier, partager, découvrir, acheter et vendre du contenu 3D, VR et AR.
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
+- [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
+- [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,6 +37,9 @@
 - [Chakra UI](https://chakra-ui.com) - React アプリケーション用のシンプルで、モジュラーで、アクセシブルなコンポーネントライブラリ。
 - [HeroUI](https://www.heroui.com) - TypeScript サポートと内蔵ダークモードを備えた美しく、高速で、モダンな React UI ライブラリ。
 - [Untitled UI](https://www.untitledui.com/react) - Tailwind CSS と React Aria で構築された、世界最大のオープンソース React コンポーネントライブラリ。ピクセルパーフェクトでアクセシブルな UI を実現。
+- [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
+- [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
+- [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
 
 ## アイコン
 
@@ -52,6 +55,8 @@
 - [Isocons](https://www.isocons.app) - 製品、プロジェクト、ポスター、プレゼンテーション用のアイソメトリックアイコン。
 - [lucide-animated](https://lucide-animated.com) - 美しく作られたアニメーションアイコン。
 - [macOS Icon Gallery](https://www.macosicongallery.com) - macOS アイコンのコレクション。
+- [Hugeicons](https://hugeicons.com) - 複数スタイルで 59,000 以上のアイコン。無料のコアセットと、大規模プロジェクト向けのプロ版ライブラリを用意。
+- [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
 
@@ -62,6 +67,8 @@
 - [vectorCraftr](https://vectorcraftr.com) - すべてのイラストが商用利用無料。
 - [unDraw](https://undraw.co) - 想像し作成できるあらゆるアイデア用のオープンソースイラスト。
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - インターネットのビジュアルソース。世界中のクリエイターによって提供されています。
+- [Absurd Design](https://absurd.design) - 独特なスタイルのシュールな手描きイラストシリーズ。個人利用・商用利用ともに無料。
+- [Humaaans](https://www.humaaans.com) - 自由に組み合わせて色を変えられる人物イラスト。CC0 で公開。
 - [DrawKit](https://www.drawkit.com) - 💵 手描きの 2D・3D イラスト、アイコン、アニメーション。次のプロジェクトに最適。すべて 1 箇所に。
 - [Storyset](https://storyset.com) - 次のプロジェクト用の素晴らしい無料カスタマイズ可能イラスト。
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
@@ -86,6 +93,7 @@
 - [BARNIMAGES](https://barnimages.com) - すべての人のための無料高解像度画像。
 - [Little Visuals](https://littlevisuals.co) - 無料、高解像度画像。お好みに応じて使用 - 商用利用無料。
 - [UI Faces](https://uifaces.co) - クリエイティブプロジェクト用の無料 AI 生成アバター。
+- [Nappy](https://nappy.co) - 黒人・褐色の肌の人々を撮影した高解像度の写真。個人利用・商用利用ともに無料。
 - [Deposit Photos](https://depositphotos.com) - 💵 ロイヤリティフリーストック写真、ベクター画像、動画、音楽。
 - [Freepik](https://www.freepik.com) - 💵 数百万の無料ベクター、PSD ファイル、写真、AI 生成画像。クリエイティブプロジェクト用のプレミアムリソース。
 
@@ -93,10 +101,13 @@
 
 - [Google Fonts](https://fonts.google.com) - 1000 以上の無料ライセンスフォントファミリーのライブラリと、CSS と Android 経由での便利な使用のための API。
 - [Inter](https://rsms.me/inter/) - テキストインターフェース用の可変フォントファミリー。
+- [Fontshare](https://www.fontshare.com) - Indian Type Foundry による無料フォントサービス。個人利用・商用利用が可能な高品質書体を提供。
+- [Uncut](https://uncut.wtf) - 現代的なオープンソース書体を厳選したライブラリ。無料でダウンロードして利用可能。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 厳選された品質の商品と製品をショッピング。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
 - [Klim](https://klim.co.nz) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
+- [Pangram Pangram](https://pangrampangram.com) - 💵 高品質な書体を手がける独立系フォントファウンドリ。ライセンス購入前に無料で試用可能。
 
 ## 色
 
@@ -110,6 +121,9 @@
 - [The day's color](https://www.thedayscolor.com) - 毎日のカラーダイジェスト。
 - [Color Drop](https://colordrop.io) - 作業中のデザインやプロジェクトのインスピレーションを得るためにクリエイター向けに構築されたカラーパレットツール。
 - [Realtime Colors](https://www.realtimecolors.com) - 実際のウェブサイトの UI 上で配色とフォントの組み合わせをリアルタイムにプレビュー。コントラストの即時チェックや CSS/Tailwind エクスポートにも対応。
+- [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
+- [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
+- [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
 
 ## ツール
 
@@ -118,6 +132,9 @@
 - [Rive](https://rive.app) - ユーザーインターフェースをデザイン、構築、配信する新しい方法。
 - [Lottielab](https://www.lottielab.com) - プロダクトチーム用のモーションデザインツール。
 - [Notion Avatar Maker](https://notion-avatar.app) - Notion 風アバターの作成。
+- [Haikei](https://haikei.app) - ブラウザ上でユニークな SVG の背景、ブロブ、波などのデザインアセットを生成。
+- [ray.so](https://ray.so) - コードスニペットを共有しやすい美しい画像に変換。Raycast チームによるツール。
+- [tldraw](https://www.tldraw.com) - 図やワイヤーフレーム、アイデアをスケッチできる、共同編集対応の無限ホワイトボード。
 - [Rotato](https://rotato.app) - 💵 数分で 3D モックアップ画像と動画。
 - [Spline](https://spline.design) - 💵 3D でデザインし協力する場所。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
@@ -126,10 +143,12 @@
 - [Sketch](https://www.sketch.com) - 💵 デザイナーによる、デザイナーのためのツールキット。あなたとあなたの仕事にフォーカス。
 - [Canva](https://www.canva.com) - 💵 Canva のドラッグ＆ドロップ機能とプロフェッショナルレイアウトで素晴らしいデザインを簡単に作成。
 - [InVision](https://www.invisionapp.com) - 💵 世界最高のユーザー体験を推進するデジタル製品デザインプラットフォーム。
+- [Screen Studio](https://screen.studio) - 💵 自動ズームと滑らかなアニメーションを備えた macOS 向け画面録画ツール。洗練された製品デモに最適。
 
 ## 書籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
+- [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
 
 ## コミュニティ
@@ -138,3 +157,5 @@
 - [Uiverse](https://uiverse.io) - コミュニティが構築した UI 要素のライブラリ。HTML/CSS、Tailwind、React、Figma としてコピーできます。
 - [Sketchfab](https://sketchfab.com) - Sketchfab は 3D、VR、AR コンテンツを公開、共有、発見、売買するために使用される 3D アセットウェブサイト。
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
+- [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
+- [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Chakra UI](https://chakra-ui.com) - A simple, modular and accessible component library for React applications.
 - [HeroUI](https://www.heroui.com) - Beautiful, fast and modern React UI library with TypeScript support and built-in dark mode.
 - [Untitled UI](https://www.untitledui.com/react) - The world's largest open-source React component library, built with Tailwind CSS and React Aria for pixel-perfect, accessible interfaces.
+- [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
+- [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
+- [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
 
 ## Icons
 
@@ -52,6 +55,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Isocons](https://www.isocons.app) - Isometric icons for your products, projects, posters and presentations.
 - [lucide-animated](https://lucide-animated.com) - beautifully crafted animated icons.
 - [macOS Icon Gallery](https://www.macosicongallery.com) - A collection of macOS icons.
+- [Hugeicons](https://hugeicons.com) - 59,000+ icons across multiple styles, with a free core set and a pro library for larger projects.
+- [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
 
@@ -62,6 +67,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [vectorCraftr](https://vectorcraftr.com) - All illustrations are free for commercial use.
 - [unDraw](https://undraw.co) - Open-source illustrations for any idea you can imagine and create.
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - The internet’s source for visuals. Powered by creators everywhere.
+- [Absurd Design](https://absurd.design) - Surreal hand-drawn illustration series with a distinctive style, free for personal and commercial use.
+- [Humaaans](https://www.humaaans.com) - Mix-and-match illustrations of people you can recombine and recolor, released under CC0.
 - [DrawKit](https://www.drawkit.com) - 💵 Hand-drawn 2D & 3D illustrations, icons and animations. Perfect for your next project. All in one place.
 - [Storyset](https://storyset.com) - Awesome free customizable illustrations for your next project.
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
@@ -86,6 +93,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [BARNIMAGES](https://barnimages.com) - Free high-resolution images for everyone.
 - [Little Visuals](https://littlevisuals.co) - Free, high resolution images. Use them anyway you want - free for commercial use.
 - [UI Faces](https://uifaces.co) - Free AI-generated avatars for your creative projects.
+- [Nappy](https://nappy.co) - Beautiful high-resolution photos of Black and Brown people, free for personal and commercial use.
 - [Deposit Photos](https://depositphotos.com) - 💵 Royalty-free Stock Photos, Vector Images, Videos and Music.
 - [Freepik](https://www.freepik.com) - 💵 Millions of free vectors, PSD files, photos and AI-generated images. Premium resources for your creative projects.
 
@@ -93,10 +101,13 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 
 - [Google Fonts](https://fonts.google.com) - A library of 1,000+ free licensed font families and APIs for convenient use via CSS and Android.
 - [Inter](https://rsms.me/inter/) - A variable font family for text interfaces.
+- [Fontshare](https://www.fontshare.com) - A free font service from the Indian Type Foundry, with quality typefaces licensed for personal and commercial use.
+- [Uncut](https://uncut.wtf) - A curated library of contemporary open-source typefaces, free to download and use.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Shop quality, curated goods and products.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Shop quality, curated fonts from indie font foundries.
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
 - [Klim](https://klim.co.nz) - 💵 Shop quality, curated fonts from indie font foundries.
+- [Pangram Pangram](https://pangrampangram.com) - 💵 An independent type foundry with high-quality typefaces, free to try before you license them.
 
 ## Colors
 
@@ -110,6 +121,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [The day's color](https://www.thedayscolor.com) - The daily color digest.
 - [Color Drop](https://colordrop.io) - Color palette tool built for creatives to help get inspiration for designs or projects they're working on.
 - [Realtime Colors](https://www.realtimecolors.com) - Preview your color palette and font choices live on a real website interface, with instant contrast checking and CSS/Tailwind export.
+- [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
+- [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
+- [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
 
 ## Tools
 
@@ -118,6 +132,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Rive](https://rive.app) - A new way to design, build, and ship user interfaces
 - [Lottielab](https://www.lottielab.com) - The motion design tool for product teams.
 - [Notion Avatar Maker](https://notion-avatar.app) - Making notion-style avatars.
+- [Haikei](https://haikei.app) - Generate unique SVG backgrounds, blobs, waves and other design assets right in the browser.
+- [ray.so](https://ray.so) - Turn code snippets into beautiful images ready to share, by the makers of Raycast.
+- [tldraw](https://www.tldraw.com) - A collaborative infinite whiteboard for sketching diagrams, wireframes and ideas.
 - [Rotato](https://rotato.app) - 💵 3D mockup images and movies in minutes.
 - [Spline](https://spline.design) - 💵 A place to design and collaborate in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
@@ -126,10 +143,12 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Sketch](https://www.sketch.com) - 💵 A toolkit made by designers, for designers, that puts the focus on you and your work.
 - [Canva](https://www.canva.com) - 💵 Create stunning designs easily with Canva's drag-and-drop feature and professional layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digital product design platform powering the world's best user experiences.
+- [Screen Studio](https://screen.studio) - 💵 macOS screen recorder with automatic zoom and smooth animations for polished product demos.
 
 ## Books
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
+- [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
 
 ## Communities
@@ -138,3 +157,5 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Uiverse](https://uiverse.io) - Community-built library of UI elements. Copy as HTML/CSS, Tailwind, React and Figma.
 - [Sketchfab](https://sketchfab.com) - Sketchfab is a 3D asset website used to publish, share, discover, buy and sell 3D, VR and AR content.
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
+- [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
+- [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,6 +37,9 @@
 - [Chakra UI](https://chakra-ui.com) - 适用于 React 应用程序的简单、模块化且可访问的组件库。
 - [HeroUI](https://www.heroui.com) - 美观、快速、现代的 React UI 库，支持 TypeScript 和内置暗色模式。
 - [Untitled UI](https://www.untitledui.com/react) - 全球最大的开源 React 组件库，使用 Tailwind CSS 和 React Aria 构建，界面像素级精致且无障碍。
+- [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
+- [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
+- [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
 
 ## 图标
 
@@ -48,6 +51,8 @@
 - [Isocons](https://www.isocons.app) - 适用于您的产品、项目、海报和演示文稿的等距图标。
 - [lucide-animated](https://lucide-animated.com) - 精美制作的动画图标。
 - [Simple Icons](https://simpleicons.org) - 3000+ 流行品牌的 SVG 图标。
+- [Hugeicons](https://hugeicons.com) - 59,000+ 个多种风格的图标，包含免费核心图标集，以及面向大型项目的专业版图标库。
+- [SVGL](https://svgl.app) - 品牌 SVG 标志与字标合集，支持一键复制、下载或直接引入到你的框架中。
 - [Nucleoapp](https://nucleoapp.com) - 💵 44000+ 高质量的 SVG 图标，定期更新，适用于 UI、演示文稿和印刷项目。
 - [Icônes](https://icones.js.org) - 图标浏览器，支持即时搜索。
 - [macOS Icon Gallery](https://www.macosicongallery.com) - macOS 图标集合。
@@ -63,6 +68,8 @@
 - [vectorCraftr](https://vectorcraftr.com) - 所有插图均可免费用于商业用途。
 - [unDraw](https://undraw.co) - 开源插图，适用于您能想象和创建的任何想法。
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - 互联网的视觉来源。由全球创作者提供支持。
+- [Absurd Design](https://absurd.design) - 风格独特的超现实主义手绘插画系列，可免费用于个人和商业项目。
+- [Humaaans](https://www.humaaans.com) - 可自由拼搭、换色的人物插画库，基于 CC0 协议发布。
 - [DrawKit](https://www.drawkit.com) - 💵 手绘 2D 和 3D 插图、图标和动画。完美适用于您的下一个项目。所有资源都在一个地方。
 - [Storyset](https://storyset.com) - 为您的下一个项目提供的免费可定制插图。
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
@@ -87,6 +94,7 @@
 - [BARNIMAGES](https://barnimages.com) - 适合所有人的免费高分辨率图像。
 - [Little Visuals](https://littlevisuals.co) - 免费高分辨率图像。可以随意使用 - 免费商用。
 - [UI Faces](https://uifaces.co) - 为您的创意项目提供免费 AI 生成头像。
+- [Nappy](https://nappy.co) - 以黑人和棕色人种为主题的高分辨率精美照片，可免费用于个人和商业项目。
 - [Deposit Photos](https://depositphotos.com) - 💵 免费版权库存照片、矢量图像、视频和音乐。
 - [Freepik](https://www.freepik.com) - 💵 数百万免费矢量、PSD 文件、照片和 AI 生成图像。创意项目的优质资源。
 
@@ -94,10 +102,13 @@
 
 - [Google Fonts](https://fonts.google.com) - 一个包含 1000 多个免费授权字体家族和 API 的库，方便通过 CSS 和 Android 使用。
 - [Inter](https://rsms.me/inter/) - 一个用于文本界面的可变字体家族。
+- [Fontshare](https://www.fontshare.com) - 来自 Indian Type Foundry 的免费字体服务，提供可用于个人和商业项目的优质字体。
+- [Uncut](https://uncut.wtf) - 精选的当代开源字体库，可免费下载使用。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 购买优质、精选的商品和产品。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
 - [Klim](https://klim.co.nz) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
+- [Pangram Pangram](https://pangrampangram.com) - 💵 独立字体工作室出品的高品质字体，购买授权前可免费试用。
 
 ## 颜色
 
@@ -111,6 +122,9 @@
 - [The day's color](https://www.thedayscolor.com) - 每日色彩文摘。
 - [Color Drop](https://colordrop.io) - 为创意人士打造的调色板工具，帮助获取设计或项目工作的灵感。
 - [Realtime Colors](https://www.realtimecolors.com) - 在真实的网站界面上实时预览您的配色方案和字体选择，支持即时对比度检测和 CSS/Tailwind 导出。
+- [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
+- [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
+- [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
 
 ## 工具
 
@@ -119,6 +133,9 @@
 - [Rive](https://rive.app) - 设计、构建和发布用户界面的新方法
 - [Lottielab](https://www.lottielab.com) - 产品团队的动态设计工具。
 - [Notion Avatar Maker](https://notion-avatar.app) - 制作 notion 风格头像。
+- [Haikei](https://haikei.app) - 直接在浏览器中生成独特的 SVG 背景、色块、波浪等设计素材。
+- [ray.so](https://ray.so) - 由 Raycast 团队出品，将代码片段转换成可直接分享的精美图片。
+- [tldraw](https://www.tldraw.com) - 用于绘制图表、线框图和创意想法的协作式无限白板。
 - [Rotato](https://rotato.app) - 💵 几分钟内制作 3D 模型图像和视频。
 - [Spline](https://spline.design) - 💵 3D 设计和协作的地方。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
@@ -127,10 +144,12 @@
 - [Sketch](https://www.sketch.com) - 💵 由设计师为设计师制作的工具包，专注于您和您的工作。
 - [Canva](https://www.canva.com) - 💵 使用 Canva 的拖放功能和专业布局轻松创建令人惊叹的设计。
 - [InVision](https://www.invisionapp.com) - 💵 为世界最佳用户体验提供支持的数字产品设计平台。
+- [Screen Studio](https://screen.studio) - 💵 macOS 屏幕录制工具，自动缩放和流畅动画，适合制作精致的产品演示。
 
 ## 书籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
+- [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
 
 ## 社区
@@ -139,3 +158,5 @@
 - [Uiverse](https://uiverse.io) - 社区构建的 UI 元素库。可以复制为 HTML/CSS、Tailwind、React 和 Figma。
 - [Sketchfab](https://sketchfab.com) - Sketchfab 是一个 3D 资产网站，用于发布、分享、发现、购买和销售 3D、VR 和 AR 内容。
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
+- [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
+- [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。


### PR DESCRIPTION
## What

Adds 21 new resources to the list, synchronized across all six language versions (`README.md`, `README.zh.md`, `README.es.md`, `README.fr.md`, `README.de.md`, `README.ja.md`). Each README goes from 99 to 120 entries.

| Section | Additions |
| --- | --- |
| UI Libraries | [React Bits](https://reactbits.dev), [Base UI](https://base-ui.com), [Park UI](https://park-ui.com) |
| Icons | [Hugeicons](https://hugeicons.com), [SVGL](https://svgl.app) |
| Illustrations | [Absurd Design](https://absurd.design), [Humaaans](https://www.humaaans.com) |
| Photography | [Nappy](https://nappy.co) |
| Fonts | [Fontshare](https://www.fontshare.com), [Uncut](https://uncut.wtf), [Pangram Pangram](https://pangrampangram.com) 💵 |
| Colors | [Happy Hues](https://www.happyhues.co), [Huemint](https://huemint.com), [OKLCH Color Picker](https://oklch.com) |
| Tools | [Haikei](https://haikei.app), [ray.so](https://ray.so), [tldraw](https://www.tldraw.com), [Screen Studio](https://screen.studio) 💵 |
| Books | [Laws of UX](https://lawsofux.com) |
| Communities | [Awwwards](https://www.awwwards.com), [Mobbin](https://mobbin.com) 💵 |

## How each entry was vetted

Since this list is about design, every candidate was actually looked at rather than just link-checked:

1. **Rendered in a real browser** — each site was loaded in headless Chromium at 1280×820 and screenshotted, then reviewed for visual quality. Anything plain, cluttered, or template-looking was dropped.
2. **URL verified** — every added URL returns HTTP 200.
3. **Duplicate check** — none of the 21 already appear in any language version.

Candidates that were checked and **rejected**, for the record:

- A stock-illustration site whose domain had been taken over by an unrelated gambling page — caught only because the page was actually rendered.
- Several otherwise useful sites (an icon framework aggregator, a self-hosted font CDN, a platform template gallery, a stock photo site) whose pages were functional but visually plain or ad-heavy, which does not fit the bar for this list.
- A few sites that could not be rendered from this environment because of bot protection, so their design could not be confirmed. They were left out rather than added unverified.

## Formatting

- Existing format kept exactly: `- [Name](URL) - Description.`
- 💵 used for paid resources, and paid entries placed after the free ones within each section, matching the existing convention.
- Descriptions are written natively in each language, not machine-translated placeholders.