### PR TITLE
Add 32 curated design resources across all six language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,6 +40,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
 - [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
 - [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
+- [Ark UI](https://ark-ui.com) - Eine Headless-Bibliothek mit über 45 barrierefreien Komponenten für React, Solid, Vue und Svelte, die du mit deinem eigenen Designsystem gestaltest.
+- [Flowbite](https://flowbite.com) - Eine Open-Source-Bibliothek mit über 600 UI-Komponenten, Sektionen und Seiten auf Basis von Tailwind CSS, entworfen in Figma.
+- [Once UI](https://once-ui.com) - Ein Open-Source-Designsystem mit über 100 vorgestylten Komponenten sowie Themes und Styles, die in einer einzigen Datei verwaltet werden.
+- [Kokonut UI](https://kokonutui.com) - Über 100 moderne Komponenten auf Basis von Tailwind CSS, shadcn/ui und Motion, die du frei in dein Projekt kopieren kannst.
 
 ## Icons
 
@@ -57,6 +61,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Eine Sammlung von macOS-Icons.
 - [Hugeicons](https://hugeicons.com) - Über 59.000 Icons in mehreren Stilen, mit kostenlosem Basis-Set und Pro-Bibliothek für größere Projekte.
 - [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
+- [3dicons](https://3dicons.co) - Über 1500 handgefertigte 3D-Icon-Renderings, kostenlos und quelloffen, mit optionalen Premium-Paketen.
+- [Iconbuddy](https://iconbuddy.com) - Eine Suchmaschine für über 300.000 quelloffene SVG-Icons, mit sofortiger Bearbeitung und Download.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
 
@@ -69,6 +75,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - Die Internet-Quelle für Visuals. Angetrieben von Creators überall.
 - [Absurd Design](https://absurd.design) - Surreale, handgezeichnete Illustrationsserien mit unverwechselbarem Stil, kostenlos für private und kommerzielle Nutzung.
 - [Humaaans](https://www.humaaans.com) - Kombinierbare Personen-Illustrationen zum Neuzusammenstellen und Umfärben, veröffentlicht unter CC0.
+- [ManyPixels](https://www.manypixels.co/gallery) - Kostenlose Illustrationen in mehreren fertigen Stilen, umfärbbar und als SVG oder PNG herunterladbar.
 - [DrawKit](https://www.drawkit.com) - 💵 Handgezeichnete 2D & 3D Illustrationen, Icons und Animationen. Perfekt für Ihr nächstes Projekt. Alles an einem Ort.
 - [Storyset](https://storyset.com) - Großartige kostenlose anpassbare Illustrationen für Ihr nächstes Projekt.
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
@@ -77,10 +84,13 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 
 ## Vorlagen
 
+- [Vercel Templates](https://vercel.com/templates) - Fertige, direkt deploybare Starter von Vercel und der Community – für Blogs, Commerce, Dashboards und mehr.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Schön gestaltete, fachmännisch gefertigte Komponenten und Vorlagen, erstellt von den Machern von Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Moderne und minimalistische Vorlagen für Ihr nächstes Produkt. Erstellt mit React, NextJS, TailwindCSS, Framer Motion und TypeScript.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
 - [Preline](https://preline.co) - 💵 Eine Open-Source Tailwind CSS-Komponentenbibliothek für alle Bedürfnisse. Kommt mit UI-Beispielen & Blöcken, Vorlagen, Plugins, Figma-Designsystem und mehr.
+- [Cruip](https://cruip.com) - 💵 Landingpages, Websites und Dashboards auf Basis von Tailwind CSS, umgesetzt in HTML, React, Next.js und Vue.
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 Über 1800 Blöcke und 2000 Komponenten, maßgeschneidert für shadcn/ui, Tailwind und React.
 
 ## Fotografie
 
@@ -94,6 +104,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Little Visuals](https://littlevisuals.co) - Kostenlose, hochauflösende Bilder. Verwenden Sie sie, wie Sie wollen - kostenlos für kommerzielle Nutzung.
 - [UI Faces](https://uifaces.co) - Kostenlose KI-generierte Avatare für Ihre kreativen Projekte.
 - [Nappy](https://nappy.co) - Schöne hochauflösende Fotos von Schwarzen und Brown People, kostenlos für private und kommerzielle Nutzung.
+- [Gratisography](https://gratisography.com) - Kostenlose hochauflösende Stockfotos mit eigenwilligem, unverwechselbarem Stil – frei für private und kommerzielle Nutzung.
+- [picjumbo](https://picjumbo.com) - Kostenlose Bilder, Hintergründe und Fotos für Websites, Templates und Blogbeiträge – regelmäßig aktualisiert.
 - [Deposit Photos](https://depositphotos.com) - 💵 Lizenzfreie Stock-Fotos, Vektorbilder, Videos und Musik.
 - [Freepik](https://www.freepik.com) - 💵 Millionen kostenloser Vektoren, PSD-Dateien, Fotos und KI-generierter Bilder. Premium-Ressourcen für Ihre kreativen Projekte.
 
@@ -103,6 +115,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Inter](https://rsms.me/inter/) - Eine variable Schriftfamilie für Text-Benutzeroberflächen.
 - [Fontshare](https://www.fontshare.com) - Ein kostenloser Font-Dienst der Indian Type Foundry mit hochwertigen Schriften für private und kommerzielle Nutzung.
 - [Uncut](https://uncut.wtf) - Eine kuratierte Bibliothek zeitgenössischer Open-Source-Schriften, kostenlos zum Herunterladen und Verwenden.
+- [Typewolf](https://www.typewolf.com) - Typografie-Trends im Blick: Font-Listen, Lookbooks und Typografie-Ressourcen mit Beispielen aus der Praxis.
+- [Fonts In Use](https://fontsinuse.com) - Ein unabhängiges Typografie-Archiv, erschlossen nach Schriftart, Format und Branche.
+- [Fontsource](https://fontsource.org) - Open-Source-Schriften als npm-Pakete selbst hosten – über 2000 Familien inklusive Variable-Font-Unterstützung.
+- [Fontpair](https://www.fontpair.co) - Kuratierte Google-Fonts-Kombinationen, die sich vor der Wahl an echten Layouts testen lassen.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Kaufen Sie kuratierte Qualitätsprodukte und Waren.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
@@ -124,6 +140,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
 - [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
 - [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
+- [Radix Colors](https://www.radix-ui.com/colors) - Ein ansprechendes, barrierefreies Farbsystem mit 12 Stufen für Interfaces, inklusive passender Dark-Mode-Skalen.
+- [UI Colors](https://uicolors.app) - Tailwind-CSS-Farbgenerator, der deine Palette direkt auf Komponenten, Dashboards und Diagrammen zeigt.
 
 ## Werkzeuge
 
@@ -135,6 +153,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Haikei](https://haikei.app) - Erzeuge einzigartige SVG-Hintergründe, Blobs, Wellen und weitere Design-Assets direkt im Browser.
 - [ray.so](https://ray.so) - Verwandelt Code-Snippets in schöne, teilbare Bilder – von den Machern von Raycast.
 - [tldraw](https://www.tldraw.com) - Ein kollaboratives, unendliches Whiteboard zum Skizzieren von Diagrammen, Wireframes und Ideen.
+- [Excalidraw](https://excalidraw.com) - Ein virtuelles Whiteboard im Handzeichnungs-Stil für Diagramme, Wireframes und Ideenskizzen.
+- [Squoosh](https://squoosh.app) - Bilder direkt im Browser komprimieren und über verschiedene Codecs und Einstellungen vergleichen – komplett clientseitig.
+- [fffuel](https://www.fffuel.co) - Eine Sammlung kostenloser SVG-Generatoren und Farbwerkzeuge für Verläufe, Muster, Texturen, Formen und Blobs.
+- [Super Designer](https://superdesigner.co) - Über 30 kostenlose Generatoren für Hintergründe, Verläufe, Muster, CSS-Schatten und OG-Bilder – ohne Anmeldung.
 - [Rotato](https://rotato.app) - 💵 3D-Mockup-Bilder und Filme in Minuten.
 - [Spline](https://spline.design) - 💵 Ein Ort zum Entwerfen und Zusammenarbeiten in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
@@ -144,12 +166,18 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Canva](https://www.canva.com) - 💵 Erstellen Sie mühelos atemberaubende Designs mit Canvas Drag & Drop-Funktion und professionellen Layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digitale Produktdesign-Plattform für die weltbesten Benutzererfahrungen.
 - [Screen Studio](https://screen.studio) - 💵 macOS-Bildschirmrekorder mit automatischem Zoom und weichen Animationen für polierte Produkt-Demos.
+- [Jitter](https://jitter.video) - 💵 Ein schnelles, einfaches Motion-Design-Tool im Browser, um Interfaces zu animieren und als Video zu exportieren.
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 Über 5200 Geräte-, Print- und Lifestyle-Mockups, in die du deine Screens einsetzen kannst.
 
 ## Bücher
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
 - [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
+- [Practical Typography](https://practicaltypography.com) - Buttericks praktischer Typografie-Leitfaden – von den Grundregeln bis zu Satz und Seitenlayout.
+- [Inclusive Components](https://inclusive-components.design) - Ein Blog, der eine Pattern-Library sein möchte – Stück für Stück über das Gestalten inklusiver Web-Interfaces.
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimeros Buch über das Handwerk des Designs, seine Absicht und die Geschichten, die es erzählt. Online frei lesbar.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
+- [Every Layout](https://every-layout.dev) - 💵 CSS-Layout neu lernen – anhand einfacher, kombinierbarer Layout-Primitive.
 
 ## Communities
 
@@ -158,4 +186,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Sketchfab](https://sketchfab.com) - Sketchfab ist eine 3D-Asset-Website zum Veröffentlichen, Teilen, Entdecken, Kaufen und Verkaufen von 3D-, VR- und AR-Inhalten.
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
 - [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
+- [Dribbble](https://dribbble.com) - Die weltweit führende Community, in der Kreative ihre Arbeiten teilen, wachsen und Aufträge finden.
+- [Behance](https://www.behance.net) - Adobes Plattform, um kreative Arbeiten von Designern aus aller Welt zu zeigen und zu entdecken.
+- [Godly](https://godly.website) - Eine tägliche Auswahl herausragender Designs aus Web, Branding, Typografie, Motion und 3D.
+- [Refero](https://refero.design) - Eine durchsuchbare Bibliothek echter Produkt-Screens, Flows und Patterns aus Web- und iOS-Apps.
 - [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
 - [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
+- [Ark UI](https://ark-ui.com) - Una biblioteca headless con más de 45 componentes accesibles para React, Solid, Vue y Svelte, lista para aplicar tu propio sistema de diseño.
+- [Flowbite](https://flowbite.com) - Una biblioteca de código abierto con más de 600 componentes, secciones y páginas construidos con Tailwind CSS y diseñados en Figma.
+- [Once UI](https://once-ui.com) - Un sistema de diseño de código abierto con más de 100 componentes preestilizados y temas y estilos gestionados desde un solo archivo.
+- [Kokonut UI](https://kokonutui.com) - Más de 100 componentes modernos construidos con Tailwind CSS, shadcn/ui y Motion, listos para copiar en tu proyecto.
 
 ## Iconos
 
@@ -57,6 +61,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Una colección de iconos de macOS.
 - [Hugeicons](https://hugeicons.com) - Más de 59.000 iconos en múltiples estilos, con un set básico gratuito y una biblioteca pro para proyectos mayores.
 - [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
+- [3dicons](https://3dicons.co) - Más de 1500 iconos 3D renderizados a mano, gratuitos y de código abierto, con packs premium opcionales.
+- [Iconbuddy](https://iconbuddy.com) - Un buscador de más de 300 000 iconos SVG de código abierto, con edición y descarga instantáneas.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
 
@@ -69,6 +75,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - La fuente de visuales del internet. Impulsado por creadores de todas partes.
 - [Absurd Design](https://absurd.design) - Series de ilustraciones surrealistas dibujadas a mano con un estilo distintivo, gratis para uso personal y comercial.
 - [Humaaans](https://www.humaaans.com) - Ilustraciones de personas combinables y recoloreables, publicadas bajo CC0.
+- [ManyPixels](https://www.manypixels.co/gallery) - Ilustraciones gratuitas en varios estilos predefinidos, con colores personalizables y descarga en SVG o PNG.
 - [DrawKit](https://www.drawkit.com) - 💵 Ilustraciones, iconos y animaciones dibujadas a mano en 2D y 3D. Perfectas para tu próximo proyecto. Todo en un lugar.
 - [Storyset](https://storyset.com) - Increíbles ilustraciones personalizables gratuitas para tu próximo proyecto.
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
@@ -77,10 +84,13 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 
 ## Plantillas
 
+- [Vercel Templates](https://vercel.com/templates) - Plantillas listas para desplegar de Vercel y la comunidad, para blogs, comercio, paneles y mucho más.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Componentes y plantillas hermosamente diseñados y expertamente elaborados, construidos por los creadores de Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Plantillas modernas y minimalistas para construir tu próximo producto. Construidas con React, NextJS, TailwindCSS, Framer Motion y Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
 - [Preline](https://preline.co) - 💵 Una librería de componentes Tailwind CSS de código abierto para cualquier necesidad. Viene con ejemplos y bloques UI, plantillas, plugins, sistema de diseño Figma y más.
+- [Cruip](https://cruip.com) - 💵 Landing pages, sitios web y paneles basados en Tailwind CSS y programados en HTML, React, Next.js y Vue.
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 Más de 1800 bloques y 2000 componentes creados a medida para shadcn/ui, Tailwind y React.
 
 ## Fotografía
 
@@ -94,6 +104,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Little Visuals](https://littlevisuals.co) - Imágenes gratuitas de alta resolución. Úsalas como quieras - gratis para uso comercial.
 - [UI Faces](https://uifaces.co) - Avatares gratuitos generados por IA para tus proyectos creativos.
 - [Nappy](https://nappy.co) - Hermosas fotos en alta resolución de personas negras y morenas, gratis para uso personal y comercial.
+- [Gratisography](https://gratisography.com) - Fotos de stock gratuitas en alta resolución con un estilo peculiar y único, libres para uso personal y comercial.
+- [picjumbo](https://picjumbo.com) - Imágenes, fondos y fotos gratuitas para sitios web, plantillas y artículos de blog, con actualizaciones periódicas.
 - [Deposit Photos](https://depositphotos.com) - 💵 Fotos de stock libres de derechos, imágenes vectoriales, videos y música.
 - [Freepik](https://www.freepik.com) - 💵 Millones de vectores gratuitos, archivos PSD, fotos e imágenes generadas por IA. Recursos premium para tus proyectos creativos.
 
@@ -103,6 +115,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Inter](https://rsms.me/inter/) - Una familia de fuentes variable para interfaces de texto.
 - [Fontshare](https://www.fontshare.com) - Un servicio de fuentes gratuito de Indian Type Foundry, con tipografías de calidad licenciadas para uso personal y comercial.
 - [Uncut](https://uncut.wtf) - Una biblioteca curada de tipografías contemporáneas de código abierto, gratis para descargar y usar.
+- [Typewolf](https://www.typewolf.com) - Las tendencias tipográficas del momento: listas de fuentes, lookbooks y recursos de tipografía con ejemplos reales.
+- [Fonts In Use](https://fontsinuse.com) - Un archivo independiente de tipografía, indexado por tipo de letra, formato e industria.
+- [Fontsource](https://fontsource.org) - Autoaloja fuentes de código abierto como paquetes npm, con más de 2000 familias y soporte para fuentes variables.
+- [Fontpair](https://www.fontpair.co) - Combinaciones de Google Fonts seleccionadas que puedes previsualizar en maquetas reales antes de elegir.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Compra productos y bienes de calidad y curados.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
@@ -124,6 +140,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
 - [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
 - [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un sistema de color accesible de 12 pasos para interfaces, con escalas equivalentes para modo oscuro.
+- [UI Colors](https://uicolors.app) - Generador de colores para Tailwind CSS que previsualiza tu paleta en componentes, paneles y gráficos.
 
 ## Herramientas
 
@@ -135,6 +153,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Haikei](https://haikei.app) - Genera fondos SVG únicos, blobs, ondas y otros recursos de diseño directamente en el navegador.
 - [ray.so](https://ray.so) - Convierte fragmentos de código en imágenes bonitas listas para compartir, de los creadores de Raycast.
 - [tldraw](https://www.tldraw.com) - Una pizarra infinita colaborativa para bocetar diagramas, wireframes e ideas.
+- [Excalidraw](https://excalidraw.com) - Una pizarra virtual con estilo dibujado a mano para bocetar diagramas, wireframes e ideas.
+- [Squoosh](https://squoosh.app) - Comprime y compara imágenes en el navegador con distintos códecs y ajustes, todo del lado del cliente.
+- [fffuel](https://www.fffuel.co) - Una colección de generadores SVG y herramientas de color gratuitas para degradados, patrones, texturas, formas y blobs.
+- [Super Designer](https://superdesigner.co) - Más de 30 generadores gratuitos de fondos, degradados, patrones, sombras CSS e imágenes OG. Sin registro.
 - [Rotato](https://rotato.app) - 💵 Imágenes mockup 3D y películas en minutos.
 - [Spline](https://spline.design) - 💵 Un lugar para diseñar y colaborar en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
@@ -144,12 +166,18 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Canva](https://www.canva.com) - 💵 Crea diseños impresionantes fácilmente con la función de arrastrar y soltar de Canva y diseños profesionales.
 - [InVision](https://www.invisionapp.com) - 💵 Plataforma de diseño de productos digitales que impulsa las mejores experiencias de usuario del mundo.
 - [Screen Studio](https://screen.studio) - 💵 Grabador de pantalla para macOS con zoom automático y animaciones suaves para demos de producto pulidas.
+- [Jitter](https://jitter.video) - 💵 Una herramienta de motion design web, rápida y sencilla, para animar interfaces y exportar vídeos.
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 Más de 5200 mockups de dispositivos, impresos y de estilo de vida en los que colocar tus pantallas.
 
 ## Libros
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
+- [Practical Typography](https://practicaltypography.com) - La guía práctica de tipografía de Butterick, desde las reglas esenciales hasta la composición y el diseño de página.
+- [Inclusive Components](https://inclusive-components.design) - Un blog que aspira a ser una biblioteca de patrones, sobre cómo diseñar interfaces web inclusivas, pieza a pieza.
+- [The Shape of Design](https://shapeofdesignbook.com) - El libro de Frank Chimero sobre el oficio del diseño, su intención y las historias que cuenta. Lectura online gratuita.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
+- [Every Layout](https://every-layout.dev) - 💵 Reaprende el layout en CSS a través de un conjunto de primitivas de maquetación simples y componibles.
 
 ## Comunidades
 
@@ -158,4 +186,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Sketchfab](https://sketchfab.com) - Sketchfab es un sitio web de recursos 3D usado para publicar, compartir, descubrir, comprar y vender contenido 3D, VR y AR.
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
 - [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
+- [Dribbble](https://dribbble.com) - La principal comunidad mundial donde los creativos comparten su trabajo, crecen y consiguen encargos.
+- [Behance](https://www.behance.net) - La plataforma de Adobe para mostrar y descubrir el trabajo creativo de diseñadores de todo el mundo.
+- [Godly](https://godly.website) - Una curaduría diaria de diseño excepcional en web, branding, tipografía, motion y 3D.
+- [Refero](https://refero.design) - Una biblioteca buscable de pantallas, flujos y patrones reales de productos web e iOS.
 - [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,6 +40,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
 - [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
+- [Ark UI](https://ark-ui.com) - Une bibliothèque headless de plus de 45 composants accessibles pour React, Solid, Vue et Svelte, à styliser avec votre propre design system.
+- [Flowbite](https://flowbite.com) - Une bibliothèque open source de plus de 600 composants, sections et pages construits avec Tailwind CSS et conçus dans Figma.
+- [Once UI](https://once-ui.com) - Un design system open source avec plus de 100 composants pré-stylés, dont les thèmes et styles se gèrent dans un seul fichier.
+- [Kokonut UI](https://kokonutui.com) - Plus de 100 composants modernes construits avec Tailwind CSS, shadcn/ui et Motion, à copier librement dans vos projets.
 
 ## Icônes
 
@@ -57,6 +61,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [macOS Icon Gallery](https://www.macosicongallery.com) - Une collection d'icônes macOS.
 - [Hugeicons](https://hugeicons.com) - Plus de 59 000 icônes en plusieurs styles, avec un jeu de base gratuit et une bibliothèque pro pour les projets plus ambitieux.
 - [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
+- [3dicons](https://3dicons.co) - Plus de 1500 icônes 3D réalisées à la main, gratuites et open source, avec des packs premium en option.
+- [Iconbuddy](https://iconbuddy.com) - Un moteur de recherche parmi plus de 300 000 icônes SVG open source, avec édition et téléchargement instantanés.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
 
@@ -69,6 +75,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - La source internet pour les visuels. Alimentée par des créateurs de partout.
 - [Absurd Design](https://absurd.design) - Séries d'illustrations surréalistes dessinées à la main au style singulier, gratuites pour un usage personnel et commercial.
 - [Humaaans](https://www.humaaans.com) - Illustrations de personnages à combiner et recolorer librement, publiées sous licence CC0.
+- [ManyPixels](https://www.manypixels.co/gallery) - Des illustrations gratuites en plusieurs styles prêts à l'emploi, recolorables et téléchargeables en SVG ou PNG.
 - [DrawKit](https://www.drawkit.com) - 💵 Illustrations, icônes et animations 2D et 3D dessinées à la main. Parfaites pour votre prochain projet. Tout en un lieu.
 - [Storyset](https://storyset.com) - Formidables illustrations personnalisables gratuites pour votre prochain projet.
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
@@ -77,10 +84,13 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 
 ## Modèles
 
+- [Vercel Templates](https://vercel.com/templates) - Des starters prêts à déployer signés Vercel et la communauté : blogs, e-commerce, tableaux de bord et plus encore.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Composants et modèles magnifiquement conçus et expertement créés, construits par les créateurs de Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modèles modernes et minimalistes pour construire votre prochain produit. Construits avec React, NextJS, TailwindCSS, Framer Motion et Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
 - [Preline](https://preline.co) - 💵 Une bibliothèque de composants Tailwind CSS open source pour tous les besoins. Livré avec des exemples et blocs UI, modèles, plugins, système de design Figma et plus.
+- [Cruip](https://cruip.com) - 💵 Landing pages, sites et tableaux de bord basés sur Tailwind CSS et codés en HTML, React, Next.js et Vue.
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 Plus de 1800 blocs et 2000 composants conçus sur mesure pour shadcn/ui, Tailwind et React.
 
 ## Photographie
 
@@ -94,6 +104,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Little Visuals](https://littlevisuals.co) - Images gratuites, haute résolution. Utilisez-les comme vous voulez - gratuit pour usage commercial.
 - [UI Faces](https://uifaces.co) - Avatars gratuits générés par IA pour vos projets créatifs.
 - [Nappy](https://nappy.co) - De belles photos haute résolution de personnes noires et métisses, gratuites pour un usage personnel et commercial.
+- [Gratisography](https://gratisography.com) - Des photos libres en haute résolution au style décalé et unique, gratuites pour un usage personnel et commercial.
+- [picjumbo](https://picjumbo.com) - Des images, fonds et photos gratuits pour sites web, templates et articles de blog, mis à jour régulièrement.
 - [Deposit Photos](https://depositphotos.com) - 💵 Photos stock libres de droits, images vectorielles, vidéos et musique.
 - [Freepik](https://www.freepik.com) - 💵 Millions de vecteurs gratuits, fichiers PSD, photos et images générées par IA. Ressources premium pour vos projets créatifs.
 
@@ -103,6 +115,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Inter](https://rsms.me/inter/) - Une famille de polices variable pour interfaces texte.
 - [Fontshare](https://www.fontshare.com) - Un service de polices gratuit de l'Indian Type Foundry, avec des typographies de qualité sous licence personnelle et commerciale.
 - [Uncut](https://uncut.wtf) - Une bibliothèque sélectionnée de typographies contemporaines open source, libres de téléchargement et d'utilisation.
+- [Typewolf](https://www.typewolf.com) - Les tendances typographiques du moment : listes de polices, lookbooks et ressources illustrées d'exemples réels.
+- [Fonts In Use](https://fontsinuse.com) - Une archive indépendante de la typographie, indexée par police, format et secteur d'activité.
+- [Fontsource](https://fontsource.org) - Hébergez vous-même des polices open source sous forme de paquets npm : plus de 2000 familles et support des polices variables.
+- [Fontpair](https://www.fontpair.co) - Des associations de Google Fonts sélectionnées, à prévisualiser sur de vraies mises en page avant de choisir.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Achetez des produits et biens de qualité, sélectionnés.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
@@ -124,6 +140,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
 - [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
 - [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un système de couleurs accessible en 12 paliers pour les interfaces, avec des échelles équivalentes en mode sombre.
+- [UI Colors](https://uicolors.app) - Générateur de couleurs Tailwind CSS qui prévisualise votre palette sur des composants, tableaux de bord et graphiques.
 
 ## Outils
 
@@ -135,6 +153,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Haikei](https://haikei.app) - Générez des arrière-plans SVG uniques, blobs, vagues et autres ressources de design directement dans le navigateur.
 - [ray.so](https://ray.so) - Transformez des extraits de code en belles images prêtes à partager, par les créateurs de Raycast.
 - [tldraw](https://www.tldraw.com) - Un tableau blanc infini et collaboratif pour esquisser diagrammes, wireframes et idées.
+- [Excalidraw](https://excalidraw.com) - Un tableau blanc virtuel au style dessiné à la main pour croquer diagrammes, wireframes et idées.
+- [Squoosh](https://squoosh.app) - Compressez et comparez des images dans le navigateur avec différents codecs et réglages, entièrement côté client.
+- [fffuel](https://www.fffuel.co) - Une collection de générateurs SVG et d'outils de couleur gratuits pour dégradés, motifs, textures, formes et blobs.
+- [Super Designer](https://superdesigner.co) - Plus de 30 générateurs gratuits de fonds, dégradés, motifs, ombres CSS et images OG. Sans inscription.
 - [Rotato](https://rotato.app) - 💵 Images de maquette 3D et films en minutes.
 - [Spline](https://spline.design) - 💵 Un lieu pour concevoir et collaborer en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
@@ -144,12 +166,18 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Canva](https://www.canva.com) - 💵 Créez facilement des designs époustouflants avec la fonction glisser-déposer de Canva et des mises en page professionnelles.
 - [InVision](https://www.invisionapp.com) - 💵 Plateforme de design de produit numérique alimentant les meilleures expériences utilisateur du monde.
 - [Screen Studio](https://screen.studio) - 💵 Enregistreur d'écran macOS avec zoom automatique et animations fluides pour des démos produit soignées.
+- [Jitter](https://jitter.video) - 💵 Un outil de motion design web, rapide et simple, pour animer des interfaces et exporter des vidéos.
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 Plus de 5200 mockups d'appareils, d'imprimés et de scènes lifestyle où glisser vos écrans.
 
 ## Livres
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
+- [Practical Typography](https://practicaltypography.com) - Le guide pratique de typographie de Butterick, des règles essentielles à la composition et à la mise en page.
+- [Inclusive Components](https://inclusive-components.design) - Un blog qui se veut bibliothèque de patterns, consacré à la conception d'interfaces web inclusives, composant par composant.
+- [The Shape of Design](https://shapeofdesignbook.com) - Le livre de Frank Chimero sur l'artisanat du design, son intention et les histoires qu'il raconte. Lecture en ligne gratuite.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
+- [Every Layout](https://every-layout.dev) - 💵 Réapprenez la mise en page CSS grâce à un ensemble de primitives simples et composables.
 
 ## Communautés
 
@@ -158,4 +186,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Sketchfab](https://sketchfab.com) - Sketchfab est un site web d'actifs 3D utilisé pour publier, partager, découvrir, acheter et vendre du contenu 3D, VR et AR.
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
 - [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
+- [Dribbble](https://dribbble.com) - La principale communauté mondiale où les créatifs partagent leur travail, progressent et trouvent des missions.
+- [Behance](https://www.behance.net) - La plateforme d'Adobe pour présenter et découvrir le travail créatif de designers du monde entier.
+- [Godly](https://godly.website) - Une sélection quotidienne de design d'exception : web, branding, typographie, motion et 3D.
+- [Refero](https://refero.design) - Une bibliothèque consultable d'écrans, de parcours et de patterns réels issus d'applications web et iOS.
 - [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,10 @@
 - [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
 - [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
 - [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
+- [Ark UI](https://ark-ui.com) - React、Solid、Vue、Svelte に対応した 45 以上のアクセシブルなヘッドレスコンポーネント。自分のデザインシステムでスタイリングできます。
+- [Flowbite](https://flowbite.com) - Tailwind CSS で構築され Figma でデザインされた 600 以上の UI コンポーネント、セクション、ページを揃えたオープンソースライブラリ。
+- [Once UI](https://once-ui.com) - 100 以上のスタイル済みコンポーネントを備えたオープンソースのデザインシステム。テーマとスタイルを 1 つのファイルで管理できます。
+- [Kokonut UI](https://kokonutui.com) - Tailwind CSS、shadcn/ui、Motion で作られた 100 以上のモダンなコンポーネント。自由にコピーして利用できます。
 
 ## アイコン
 
@@ -57,6 +61,8 @@
 - [macOS Icon Gallery](https://www.macosicongallery.com) - macOS アイコンのコレクション。
 - [Hugeicons](https://hugeicons.com) - 複数スタイルで 59,000 以上のアイコン。無料のコアセットと、大規模プロジェクト向けのプロ版ライブラリを用意。
 - [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
+- [3dicons](https://3dicons.co) - 手作業で制作された 1500 以上の 3D アイコンレンダー。無料・オープンソースで、プレミアムパックも用意されています。
+- [Iconbuddy](https://iconbuddy.com) - 30 万以上のオープンソース SVG アイコンを横断検索できるエンジン。その場で編集してダウンロードできます。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
 
@@ -69,6 +75,7 @@
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - インターネットのビジュアルソース。世界中のクリエイターによって提供されています。
 - [Absurd Design](https://absurd.design) - 独特なスタイルのシュールな手描きイラストシリーズ。個人利用・商用利用ともに無料。
 - [Humaaans](https://www.humaaans.com) - 自由に組み合わせて色を変えられる人物イラスト。CC0 で公開。
+- [ManyPixels](https://www.manypixels.co/gallery) - 複数のスタイルから選べる無料イラスト集。色を変更して SVG や PNG でダウンロードできます。
 - [DrawKit](https://www.drawkit.com) - 💵 手描きの 2D・3D イラスト、アイコン、アニメーション。次のプロジェクトに最適。すべて 1 箇所に。
 - [Storyset](https://storyset.com) - 次のプロジェクト用の素晴らしい無料カスタマイズ可能イラスト。
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
@@ -77,10 +84,13 @@
 
 ## テンプレート
 
+- [Vercel Templates](https://vercel.com/templates) - Vercel とコミュニティによる、そのままデプロイできるスターター集。ブログ、EC、ダッシュボードなど幅広く対応。
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Tailwind CSS の制作者による美しくデザインされ、専門的に作られたコンポーネントとテンプレート。
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 次の製品を構築するためのモダンでミニマリストなテンプレート。React、NextJS、TailwindCSS、Framer Motion、TypeScript で構築。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
 - [Preline](https://preline.co) - 💵 あらゆるニーズに対応するオープンソース Tailwind CSS コンポーネントライブラリ。UI サンプル＆ブロック、テンプレート、プラグイン、Figma デザインシステムなどが付属。
+- [Cruip](https://cruip.com) - 💵 Tailwind CSS ベースのランディングページ、Web サイト、ダッシュボード。HTML、React、Next.js、Vue で実装されています。
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 shadcn/ui、Tailwind、React 向けに作られた 1800 以上のブロックと 2000 以上のコンポーネント。
 
 ## 写真
 
@@ -94,6 +104,8 @@
 - [Little Visuals](https://littlevisuals.co) - 無料、高解像度画像。お好みに応じて使用 - 商用利用無料。
 - [UI Faces](https://uifaces.co) - クリエイティブプロジェクト用の無料 AI 生成アバター。
 - [Nappy](https://nappy.co) - 黒人・褐色の肌の人々を撮影した高解像度の写真。個人利用・商用利用ともに無料。
+- [Gratisography](https://gratisography.com) - ユニークで遊び心のある高解像度フリー写真素材。個人利用にも商用利用にも無料で使えます。
+- [picjumbo](https://picjumbo.com) - Web サイトやテンプレート、ブログ記事に使える無料の画像・背景・写真。定期的に更新されています。
 - [Deposit Photos](https://depositphotos.com) - 💵 ロイヤリティフリーストック写真、ベクター画像、動画、音楽。
 - [Freepik](https://www.freepik.com) - 💵 数百万の無料ベクター、PSD ファイル、写真、AI 生成画像。クリエイティブプロジェクト用のプレミアムリソース。
 
@@ -103,6 +115,10 @@
 - [Inter](https://rsms.me/inter/) - テキストインターフェース用の可変フォントファミリー。
 - [Fontshare](https://www.fontshare.com) - Indian Type Foundry による無料フォントサービス。個人利用・商用利用が可能な高品質書体を提供。
 - [Uncut](https://uncut.wtf) - 現代的なオープンソース書体を厳選したライブラリ。無料でダウンロードして利用可能。
+- [Typewolf](https://www.typewolf.com) - タイポグラフィのトレンドを追うサイト。フォントリストやルックブック、実例つきの学習リソースが揃います。
+- [Fonts In Use](https://fontsinuse.com) - 書体・フォーマット・業種で検索できる、独立系のタイポグラフィ事例アーカイブ。
+- [Fontsource](https://fontsource.org) - オープンソースフォントを npm パッケージとしてセルフホスト。2000 以上のファミリーとバリアブルフォントに対応。
+- [Fontpair](https://www.fontpair.co) - 厳選された Google Fonts の組み合わせ集。実際のレイアウト上でプレビューしてから選べます。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 厳選された品質の商品と製品をショッピング。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
@@ -124,6 +140,8 @@
 - [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
 - [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
+- [Radix Colors](https://www.radix-ui.com/colors) - UI 向けに設計された 12 段階のアクセシブルなカラーシステム。ダークモード用のスケールも揃っています。
+- [UI Colors](https://uicolors.app) - Tailwind CSS 用のカラージェネレーター。コンポーネントやダッシュボード、グラフ上でパレットを確認できます。
 
 ## ツール
 
@@ -135,6 +153,10 @@
 - [Haikei](https://haikei.app) - ブラウザ上でユニークな SVG の背景、ブロブ、波などのデザインアセットを生成。
 - [ray.so](https://ray.so) - コードスニペットを共有しやすい美しい画像に変換。Raycast チームによるツール。
 - [tldraw](https://www.tldraw.com) - 図やワイヤーフレーム、アイデアをスケッチできる、共同編集対応の無限ホワイトボード。
+- [Excalidraw](https://excalidraw.com) - 手描き風のオンラインホワイトボード。図解やワイヤーフレーム、アイデアのスケッチに最適です。
+- [Squoosh](https://squoosh.app) - ブラウザ上で画像を圧縮・比較できるツール。さまざまなコーデックと設定を試せ、処理はすべてローカルで完結します。
+- [fffuel](https://www.fffuel.co) - グラデーション、パターン、テクスチャ、シェイプ、ブロブを作れる無料 SVG ジェネレーターとカラーツールのコレクション。
+- [Super Designer](https://superdesigner.co) - 背景、グラデーション、パターン、CSS シャドウ、OG 画像を作れる 30 以上の無料ジェネレーター。登録不要です。
 - [Rotato](https://rotato.app) - 💵 数分で 3D モックアップ画像と動画。
 - [Spline](https://spline.design) - 💵 3D でデザインし協力する場所。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
@@ -144,12 +166,18 @@
 - [Canva](https://www.canva.com) - 💵 Canva のドラッグ＆ドロップ機能とプロフェッショナルレイアウトで素晴らしいデザインを簡単に作成。
 - [InVision](https://www.invisionapp.com) - 💵 世界最高のユーザー体験を推進するデジタル製品デザインプラットフォーム。
 - [Screen Studio](https://screen.studio) - 💵 自動ズームと滑らかなアニメーションを備えた macOS 向け画面録画ツール。洗練された製品デモに最適。
+- [Jitter](https://jitter.video) - 💵 Web 上で動くシンプルで高速なモーションデザインツール。UI をアニメーション化して動画で書き出せます。
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 デバイス、印刷物、ライフスタイルなど 5200 以上のモックアップ。自分の画面をはめ込むだけで完成します。
 
 ## 書籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
 - [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
+- [Practical Typography](https://practicaltypography.com) - Butterick による実践的なタイポグラフィ指南。基本ルールから文字組み、ページレイアウトまで解説します。
+- [Inclusive Components](https://inclusive-components.design) - パターンライブラリを目指すブログ。インクルーシブな Web インターフェースの作り方をコンポーネント単位で解説します。
+- [The Shape of Design](https://shapeofdesignbook.com) - デザインという営みとその意図、そして語られる物語についての Frank Chimero の著作。オンラインで無料で読めます。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
+- [Every Layout](https://every-layout.dev) - 💵 シンプルで組み合わせ可能なレイアウトプリミティブを通じて CSS レイアウトを学び直す一冊。
 
 ## コミュニティ
 
@@ -158,4 +186,8 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab は 3D、VR、AR コンテンツを公開、共有、発見、売買するために使用される 3D アセットウェブサイト。
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
 - [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
+- [Dribbble](https://dribbble.com) - 世界最大級のクリエイターコミュニティ。作品を共有し、スキルを高め、仕事につなげられます。
+- [Behance](https://www.behance.net) - 世界中のデザイナーの作品を公開・発見できる Adobe のプラットフォーム。
+- [Godly](https://godly.website) - Web、ブランディング、タイポグラフィ、モーション、3D にわたる優れたデザインを毎日キュレーション。
+- [Refero](https://refero.design) - Web および iOS アプリの実際の画面・フロー・パターンを検索できるライブラリ。
 - [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
 - [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
 - [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
+- [Ark UI](https://ark-ui.com) - A headless library of 45+ accessible components for React, Solid, Vue and Svelte, ready to be styled with your own design system.
+- [Flowbite](https://flowbite.com) - An open-source library of 600+ UI components, sections and pages built with Tailwind CSS and designed in Figma.
+- [Once UI](https://once-ui.com) - An open-source design system with 100+ pre-styled components and themes and styles managed from a single file.
+- [Kokonut UI](https://kokonutui.com) - 100+ modern components built with Tailwind CSS, shadcn/ui and Motion, free to copy into your project.
 
 ## Icons
 
@@ -57,6 +61,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [macOS Icon Gallery](https://www.macosicongallery.com) - A collection of macOS icons.
 - [Hugeicons](https://hugeicons.com) - 59,000+ icons across multiple styles, with a free core set and a pro library for larger projects.
 - [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
+- [3dicons](https://3dicons.co) - 1,500+ hand-made 3D icon renders, free and open source, with premium packs available.
+- [Iconbuddy](https://iconbuddy.com) - A search engine across 300,000+ open source SVG icons, with instant editing and download.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
 
@@ -69,6 +75,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - The internet’s source for visuals. Powered by creators everywhere.
 - [Absurd Design](https://absurd.design) - Surreal hand-drawn illustration series with a distinctive style, free for personal and commercial use.
 - [Humaaans](https://www.humaaans.com) - Mix-and-match illustrations of people you can recombine and recolor, released under CC0.
+- [ManyPixels](https://www.manypixels.co/gallery) - Free illustrations in several ready-made styles, recolorable and downloadable as SVG or PNG.
 - [DrawKit](https://www.drawkit.com) - 💵 Hand-drawn 2D & 3D illustrations, icons and animations. Perfect for your next project. All in one place.
 - [Storyset](https://storyset.com) - Awesome free customizable illustrations for your next project.
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
@@ -77,10 +84,13 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 
 ## Templates
 
+- [Vercel Templates](https://vercel.com/templates) - Pre-built, deployable starters from Vercel and the community, covering blogs, commerce, dashboards and more.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵Beautifully designed, expertly crafted components and templates, built by the makers of Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modern and minimalist templates for building your next product. Built with React, NextJS, TailwindCSS, Framer Motion and Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
 - [Preline](https://preline.co) - 💵 An open-source Tailwind CSS components library for any needs. Comes with UI examples & blocks, templates, plugins, Figma design system and more.
+- [Cruip](https://cruip.com) - 💵 Landing pages, websites and dashboards built on Tailwind CSS and coded in HTML, React, Next.js and Vue.
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 1,800+ blocks and 2,000+ components custom-built for shadcn/ui, Tailwind and React.
 
 ## Photography
 
@@ -94,6 +104,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Little Visuals](https://littlevisuals.co) - Free, high resolution images. Use them anyway you want - free for commercial use.
 - [UI Faces](https://uifaces.co) - Free AI-generated avatars for your creative projects.
 - [Nappy](https://nappy.co) - Beautiful high-resolution photos of Black and Brown people, free for personal and commercial use.
+- [Gratisography](https://gratisography.com) - Free high-resolution stock photos with a quirky, one-of-a-kind style, free for personal and commercial use.
+- [picjumbo](https://picjumbo.com) - Free images, backgrounds and photos for websites, templates and blog posts, updated regularly.
 - [Deposit Photos](https://depositphotos.com) - 💵 Royalty-free Stock Photos, Vector Images, Videos and Music.
 - [Freepik](https://www.freepik.com) - 💵 Millions of free vectors, PSD files, photos and AI-generated images. Premium resources for your creative projects.
 
@@ -103,6 +115,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Inter](https://rsms.me/inter/) - A variable font family for text interfaces.
 - [Fontshare](https://www.fontshare.com) - A free font service from the Indian Type Foundry, with quality typefaces licensed for personal and commercial use.
 - [Uncut](https://uncut.wtf) - A curated library of contemporary open-source typefaces, free to download and use.
+- [Typewolf](https://www.typewolf.com) - What's trending in type: font lists, lookbooks and typography resources, illustrated with real-world examples.
+- [Fonts In Use](https://fontsinuse.com) - An independent archive of typography, indexed by typeface, format and industry.
+- [Fontsource](https://fontsource.org) - Self-host open source fonts as npm packages, with 2,000+ families and variable font support.
+- [Fontpair](https://www.fontpair.co) - Curated Google Font combinations you can preview on real layouts before choosing.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Shop quality, curated goods and products.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Shop quality, curated fonts from indie font foundries.
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
@@ -124,6 +140,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
 - [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
 - [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
+- [Radix Colors](https://www.radix-ui.com/colors) - A gorgeous, accessible 12-step color system for user interfaces, with matching dark mode scales.
+- [UI Colors](https://uicolors.app) - Tailwind CSS color generator that previews your palette across components, dashboards and charts.
 
 ## Tools
 
@@ -135,6 +153,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Haikei](https://haikei.app) - Generate unique SVG backgrounds, blobs, waves and other design assets right in the browser.
 - [ray.so](https://ray.so) - Turn code snippets into beautiful images ready to share, by the makers of Raycast.
 - [tldraw](https://www.tldraw.com) - A collaborative infinite whiteboard for sketching diagrams, wireframes and ideas.
+- [Excalidraw](https://excalidraw.com) - A virtual hand-drawn style whiteboard for sketching diagrams, wireframes and ideas.
+- [Squoosh](https://squoosh.app) - Compress and compare images in the browser across different codecs and settings, entirely client-side.
+- [fffuel](https://www.fffuel.co) - A collection of free SVG generators and color tools for gradients, patterns, textures, shapes and blobs.
+- [Super Designer](https://superdesigner.co) - 30+ free generators for backgrounds, gradients, patterns, CSS shadows and OG images. No signup needed.
 - [Rotato](https://rotato.app) - 💵 3D mockup images and movies in minutes.
 - [Spline](https://spline.design) - 💵 A place to design and collaborate in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
@@ -144,12 +166,18 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Canva](https://www.canva.com) - 💵 Create stunning designs easily with Canva's drag-and-drop feature and professional layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digital product design platform powering the world's best user experiences.
 - [Screen Studio](https://screen.studio) - 💵 macOS screen recorder with automatic zoom and smooth animations for polished product demos.
+- [Jitter](https://jitter.video) - 💵 A fast and simple motion design tool on the web for animating interfaces and exporting videos.
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 5,200+ device, print and lifestyle mockups you can drop your screens into.
 
 ## Books
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
+- [Practical Typography](https://practicaltypography.com) - Butterick's practical guide to typography, from the essential rules to type composition and page layout.
+- [Inclusive Components](https://inclusive-components.design) - A blog trying to be a pattern library, all about designing inclusive web interfaces, piece by piece.
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimero's book on the craft of design, its intent and the stories it tells. Free to read online.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
+- [Every Layout](https://every-layout.dev) - 💵 Relearn CSS layout through a set of simple, composable layout primitives.
 
 ## Communities
 
@@ -158,4 +186,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Sketchfab](https://sketchfab.com) - Sketchfab is a 3D asset website used to publish, share, discover, buy and sell 3D, VR and AR content.
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
 - [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
+- [Dribbble](https://dribbble.com) - The world's leading community for creatives to share their work, grow and get hired.
+- [Behance](https://www.behance.net) - Adobe's platform to showcase and discover creative work from designers around the world.
+- [Godly](https://godly.website) - A daily curation of exceptional design across web, branding, typography, motion and 3D.
+- [Refero](https://refero.design) - A searchable library of real product screens, flows and patterns from web and iOS apps.
 - [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,10 @@
 - [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
 - [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
 - [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
+- [Ark UI](https://ark-ui.com) - 面向 React、Solid、Vue 和 Svelte 的无样式组件库，包含 45+ 个无障碍组件，可套用你自己的设计系统。
+- [Flowbite](https://flowbite.com) - 开源组件库，提供 600+ 个基于 Tailwind CSS 构建、并在 Figma 中设计的 UI 组件、区块和页面。
+- [Once UI](https://once-ui.com) - 开源设计系统，内置 100+ 个预设样式组件，主题与样式集中在单个文件中管理。
+- [Kokonut UI](https://kokonutui.com) - 100+ 个基于 Tailwind CSS、shadcn/ui 和 Motion 构建的现代组件，可免费复制到你的项目中。
 
 ## 图标
 
@@ -53,6 +57,8 @@
 - [Simple Icons](https://simpleicons.org) - 3000+ 流行品牌的 SVG 图标。
 - [Hugeicons](https://hugeicons.com) - 59,000+ 个多种风格的图标，包含免费核心图标集，以及面向大型项目的专业版图标库。
 - [SVGL](https://svgl.app) - 品牌 SVG 标志与字标合集，支持一键复制、下载或直接引入到你的框架中。
+- [3dicons](https://3dicons.co) - 1500+ 个手工制作的 3D 图标渲染图，免费开源，另有付费高级图标包。
+- [Iconbuddy](https://iconbuddy.com) - 覆盖 30 万+ 开源 SVG 图标的搜索引擎，支持即时编辑与下载。
 - [Nucleoapp](https://nucleoapp.com) - 💵 44000+ 高质量的 SVG 图标，定期更新，适用于 UI、演示文稿和印刷项目。
 - [Icônes](https://icones.js.org) - 图标浏览器，支持即时搜索。
 - [macOS Icon Gallery](https://www.macosicongallery.com) - macOS 图标集合。
@@ -70,6 +76,7 @@
 - [Unsplash Illustrations](https://unsplash.com/illustrations) - 互联网的视觉来源。由全球创作者提供支持。
 - [Absurd Design](https://absurd.design) - 风格独特的超现实主义手绘插画系列，可免费用于个人和商业项目。
 - [Humaaans](https://www.humaaans.com) - 可自由拼搭、换色的人物插画库，基于 CC0 协议发布。
+- [ManyPixels](https://www.manypixels.co/gallery) - 多种现成风格的免费插图，可自定义配色并下载为 SVG 或 PNG。
 - [DrawKit](https://www.drawkit.com) - 💵 手绘 2D 和 3D 插图、图标和动画。完美适用于您的下一个项目。所有资源都在一个地方。
 - [Storyset](https://storyset.com) - 为您的下一个项目提供的免费可定制插图。
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
@@ -78,10 +85,13 @@
 
 ## 模板
 
+- [Vercel Templates](https://vercel.com/templates) - 来自 Vercel 与社区的可一键部署起始模板，涵盖博客、电商、仪表盘等场景。
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 精美设计、专业制作的组件和模板，由 Tailwind CSS 的制作者构建。
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 现代和极简的模板，用于构建您的下一个产品。使用 React、NextJS、TailwindCSS、Framer Motion 和 Typescript 构建。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
 - [Preline](https://preline.co) - 💵 一个开源的 Tailwind CSS 组件库，适用于各种需求。提供 UI 示例和区块、模板、插件、Figma 设计系统等。
+- [Cruip](https://cruip.com) - 💵 基于 Tailwind CSS 的落地页、网站和仪表盘模板，提供 HTML、React、Next.js 和 Vue 版本。
+- [Shadcnblocks](https://www.shadcnblocks.com) - 💵 1800+ 个区块和 2000+ 个组件，专为 shadcn/ui、Tailwind 和 React 定制。
 
 ## 摄影
 
@@ -95,6 +105,8 @@
 - [Little Visuals](https://littlevisuals.co) - 免费高分辨率图像。可以随意使用 - 免费商用。
 - [UI Faces](https://uifaces.co) - 为您的创意项目提供免费 AI 生成头像。
 - [Nappy](https://nappy.co) - 以黑人和棕色人种为主题的高分辨率精美照片，可免费用于个人和商业项目。
+- [Gratisography](https://gratisography.com) - 风格独特、充满趣味的免费高分辨率图库照片，可免费用于个人和商业项目。
+- [picjumbo](https://picjumbo.com) - 适用于网站、模板和博客文章的免费图片、背景与照片，定期更新。
 - [Deposit Photos](https://depositphotos.com) - 💵 免费版权库存照片、矢量图像、视频和音乐。
 - [Freepik](https://www.freepik.com) - 💵 数百万免费矢量、PSD 文件、照片和 AI 生成图像。创意项目的优质资源。
 
@@ -104,6 +116,10 @@
 - [Inter](https://rsms.me/inter/) - 一个用于文本界面的可变字体家族。
 - [Fontshare](https://www.fontshare.com) - 来自 Indian Type Foundry 的免费字体服务，提供可用于个人和商业项目的优质字体。
 - [Uncut](https://uncut.wtf) - 精选的当代开源字体库，可免费下载使用。
+- [Typewolf](https://www.typewolf.com) - 追踪字体趋势的站点，提供字体清单、案例图集和排版资源，并配有真实网站范例。
+- [Fonts In Use](https://fontsinuse.com) - 独立的排版案例档案库，可按字体、载体和行业检索。
+- [Fontsource](https://fontsource.org) - 以 npm 包形式自托管开源字体，收录 2000+ 个字体家族并支持可变字体。
+- [Fontpair](https://www.fontpair.co) - 精选的 Google Fonts 搭配方案，可在真实版式中预览后再做选择。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 购买优质、精选的商品和产品。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
@@ -125,6 +141,8 @@
 - [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
 - [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
+- [Radix Colors](https://www.radix-ui.com/colors) - 为用户界面打造的 12 级无障碍配色系统，附带配套的深色模式色阶。
+- [UI Colors](https://uicolors.app) - Tailwind CSS 配色生成器，可在组件、仪表盘和图表中实时预览你的调色板。
 
 ## 工具
 
@@ -136,6 +154,10 @@
 - [Haikei](https://haikei.app) - 直接在浏览器中生成独特的 SVG 背景、色块、波浪等设计素材。
 - [ray.so](https://ray.so) - 由 Raycast 团队出品，将代码片段转换成可直接分享的精美图片。
 - [tldraw](https://www.tldraw.com) - 用于绘制图表、线框图和创意想法的协作式无限白板。
+- [Excalidraw](https://excalidraw.com) - 手绘风格的在线白板，用于绘制示意图、线框图和创意草图。
+- [Squoosh](https://squoosh.app) - 在浏览器中压缩并对比图片，可切换不同编码格式与参数，全程本地处理。
+- [fffuel](https://www.fffuel.co) - 免费的 SVG 生成器与配色工具合集，可制作渐变、图案、纹理、形状和不规则色块。
+- [Super Designer](https://superdesigner.co) - 30+ 个免费生成器，可制作背景、渐变、图案、CSS 阴影和 OG 图片，无需注册。
 - [Rotato](https://rotato.app) - 💵 几分钟内制作 3D 模型图像和视频。
 - [Spline](https://spline.design) - 💵 3D 设计和协作的地方。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
@@ -145,12 +167,18 @@
 - [Canva](https://www.canva.com) - 💵 使用 Canva 的拖放功能和专业布局轻松创建令人惊叹的设计。
 - [InVision](https://www.invisionapp.com) - 💵 为世界最佳用户体验提供支持的数字产品设计平台。
 - [Screen Studio](https://screen.studio) - 💵 macOS 屏幕录制工具，自动缩放和流畅动画，适合制作精致的产品演示。
+- [Jitter](https://jitter.video) - 💵 简单高效的网页端动效设计工具，可为界面制作动画并导出视频。
+- [Mockuuups Studio](https://mockuuups.studio) - 💵 5200+ 个设备、印刷和生活场景样机，可直接放入你的界面截图。
 
 ## 书籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
 - [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
+- [Practical Typography](https://practicaltypography.com) - Butterick 的实用排版指南，从核心规则讲到文字排版与页面布局。
+- [Inclusive Components](https://inclusive-components.design) - 一个立志成为模式库的博客，逐个组件讲解如何设计具有包容性的 Web 界面。
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimero 关于设计手艺、意图与叙事的著作，可在线免费阅读。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
+- [Every Layout](https://every-layout.dev) - 💵 通过一组简单、可组合的布局原语重新学习 CSS 布局。
 
 ## 社区
 
@@ -159,4 +187,8 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab 是一个 3D 资产网站，用于发布、分享、发现、购买和销售 3D、VR 和 AR 内容。
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
 - [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
+- [Dribbble](https://dribbble.com) - 全球领先的创意社区，设计师在这里分享作品、成长并获得工作机会。
+- [Behance](https://www.behance.net) - Adobe 旗下的创意作品展示与发现平台，汇聚全球设计师的作品。
+- [Godly](https://godly.website) - 每日精选的顶尖设计案例，涵盖网页、品牌、排版、动效和 3D。
+- [Refero](https://refero.design) - 可检索的真实产品界面库，收录 Web 与 iOS 应用的页面、流程和交互模式。
 - [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。


### PR DESCRIPTION
## What

Adds 32 new resources to every language README (`en`, `zh`, `es`, `fr`, `de`, `ja`), with translated descriptions for each.

| Section | Added |
| --- | --- |
| UI Libraries | Ark UI, Flowbite, Once UI, Kokonut UI |
| Icons | 3dicons, Iconbuddy |
| Illustrations | ManyPixels |
| Templates | Vercel Templates, Cruip 💵, Shadcnblocks 💵 |
| Photography | Gratisography, picjumbo |
| Fonts | Typewolf, Fonts In Use, Fontsource, Fontpair |
| Colors | Radix Colors, UI Colors |
| Tools | Excalidraw, Squoosh, fffuel, Super Designer, Jitter 💵, Mockuuups Studio 💵 |
| Books | Practical Typography, Inclusive Components, The Shape of Design, Every Layout 💵 |
| Communities | Dribbble, Behance, Godly, Refero |

## How candidates were vetted

Every candidate was loaded in a headless Chromium at 1440×900 and the rendered page was reviewed visually — the list is meant to point at resources whose own sites look designed, not just useful. Sites that turned out to be plain, dated, ad-heavy, or unverifiable were left out.

That check also caught a few things a link-only review would have missed:

- **glazestock.com** now redirects to an unrelated gambling site — excluded.
- **pixeltrue.com/free-illustrations** redirects to a paid packs page — excluded.
- Several otherwise-popular resources (Iconify's icon-sets browser, Modern Font Stacks, Hero Patterns, Feather, Leonardo) render as functional-but-plain pages and did not clear the bar.

All 32 URLs were confirmed to load. `every-layout.dev` and `behance.net` reject plain `curl` requests but load normally in a browser, which is how they were verified.

## Formatting

- Entries follow the existing `- [Name](URL) - Description` format.
- Paid resources are marked with 💵 and placed after the free entries in their section, matching the existing ordering.
- No existing entries were changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnwAh9nidYG42138U7Fsuj)_