### PR TITLE
Add 42 visually verified design resources across all six READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,6 +40,12 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
 - [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
 - [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
+- [Ark UI](https://ark-ui.com) - Eine Headless-Bibliothek mit über 45 barrierefreien Komponenten für Design-Systeme, die mit React, Vue, Solid und Svelte funktionieren.
+- [Flowbite](https://flowbite.com) - Eine Open-Source-Bibliothek mit über 600 UI-Komponenten, Abschnitten und Seiten, gebaut mit Tailwind-CSS-Utility-Klassen und in Figma gestaltet.
+- [Tremor](https://tremor.so) - Über 35 Open-Source-React-Komponenten für Diagramme und Dashboards, gebaut mit Tailwind CSS und Radix UI.
+- [Primer](https://primer.style) - Das Design-System von GitHub mit React- und CSS-Komponenten, Octicons und einem Brand-Toolkit.
+- [Material Design 3](https://m3.material.io) - Das Open-Source-Design-System von Google mit Richtlinien, Komponenten sowie Farb- und Typografie-Tokens.
+- [UIBall Loaders](https://uiball.com/loaders) - Kostenlose Open-Source-Loader und Spinner aus HTML, CSS und SVG, verfügbar als React- und Web-Components.
 
 ## Icons
 
@@ -59,6 +65,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
+- [Font Awesome](https://fontawesome.com) - Das klassische Icon-Toolkit mit Tausenden kostenlosen Icons und einer größeren Pro-Bibliothek – für Web, Desktop und Figma.
+- [Iconbuddy](https://iconbuddy.com) - Durchsuchen Sie über 300.000 Open-Source-Icons aus mehr als 200 Sets und bearbeiten und kopieren Sie sie im gewünschten Format.
+- [3D Icons](https://3dicons.co) - Über 1.500 handgefertigte 3D-Icon-Renderings, kostenlos und quelloffen.
+- [Pixelarticons](https://pixelarticons.com) - Über 4.600 handgefertigte Pixel-Art-Icons auf einem 24×24-Raster in vier Stilen.
 
 ## Illustrationen
 
@@ -74,9 +84,15 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
 - [Blush](https://blush.design) - Kostenlose anpassbare Illustrationen mit Figma-Plugin. Erstellen, bearbeiten und verwenden Sie Illustrationen in Ihren Designs.
 - [Open Peeps](https://www.openpeeps.com) - Eine handgezeichnete Illustrationsbibliothek zum Erstellen von Szenen mit Menschen. Sie können sie in Produktillustration, Marketing, Comics und mehr verwenden.
+- [Open Doodles](https://www.opendoodles.com) - Ein kostenloses Open-Source-Set handgezeichneter Illustrationen, die Sie umfärben und remixen können.
+- [illlustrations.co](https://illlustrations.co) - Ein Open-Source-Illustrationskit mit über 120 Illustrationen in AI, SVG, PNG, EPS und Figma – kostenlos für private und kommerzielle Nutzung.
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - Kostenlose Illustrationen in mehreren Stilen, umfärbbar und als SVG oder PNG herunterladbar.
 
 ## Vorlagen
 
+- [Vercel Templates](https://vercel.com/templates) - Fertige, direkt deploybare Starter für alle wichtigen Frameworks – von Vercel und der Community.
+- [Astro Themes](https://astro.build/themes/) - Themes und Starter für Astro-Websites – von kostenlosen Open-Source-Vorlagen bis zu Premium-Themes.
+- [Landingfolio](https://www.landingfolio.com) - Kuratierte Landingpage-Inspiration sowie Komponenten und Vorlagen für Tailwind, Webflow und Figma.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Schön gestaltete, fachmännisch gefertigte Komponenten und Vorlagen, erstellt von den Machern von Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Moderne und minimalistische Vorlagen für Ihr nächstes Produkt. Erstellt mit React, NextJS, TailwindCSS, Framer Motion und TypeScript.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
@@ -94,8 +110,12 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Little Visuals](https://littlevisuals.co) - Kostenlose, hochauflösende Bilder. Verwenden Sie sie, wie Sie wollen - kostenlos für kommerzielle Nutzung.
 - [UI Faces](https://uifaces.co) - Kostenlose KI-generierte Avatare für Ihre kreativen Projekte.
 - [Nappy](https://nappy.co) - Schöne hochauflösende Fotos von Schwarzen und Brown People, kostenlos für private und kommerzielle Nutzung.
+- [Kaboompics](https://kaboompics.com) - Kostenlose Stockfotos und kuratierte Fotoserien, durchsuchbar nach Farbpalette.
+- [Gratisography](https://gratisography.com) - Wirklich einzigartige, meist skurrile und immer kostenlose hochauflösende Stockfotos.
 - [Deposit Photos](https://depositphotos.com) - 💵 Lizenzfreie Stock-Fotos, Vektorbilder, Videos und Musik.
 - [Freepik](https://www.freepik.com) - 💵 Millionen kostenloser Vektoren, PSD-Dateien, Fotos und KI-generierter Bilder. Premium-Ressourcen für Ihre kreativen Projekte.
+- [Rawpixel](https://www.rawpixel.com) - 💵 Fotos, gemeinfreie Vintage-Kunstwerke, Mockups und Design-Assets.
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 Stockfotos und -videos, die Ihre Marke kulturell relevant halten.
 
 ## Schriftarten
 
@@ -103,11 +123,14 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Inter](https://rsms.me/inter/) - Eine variable Schriftfamilie für Text-Benutzeroberflächen.
 - [Fontshare](https://www.fontshare.com) - Ein kostenloser Font-Dienst der Indian Type Foundry mit hochwertigen Schriften für private und kommerzielle Nutzung.
 - [Uncut](https://uncut.wtf) - Eine kuratierte Bibliothek zeitgenössischer Open-Source-Schriften, kostenlos zum Herunterladen und Verwenden.
+- [Fontsource](https://fontsource.org) - Open-Source-Schriften als npm-Pakete selbst hosten, mit Vorschau für über 2.000 Familien.
+- [Modern Font Stacks](https://modernfontstacks.com) - Nach Schriftklassifikation geordnete System-Font-Stacks – ohne Downloads, ohne Layout-Shifts, sofort gerendert.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Kaufen Sie kuratierte Qualitätsprodukte und Waren.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
 - [Klim](https://klim.co.nz) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Eine unabhängige Schriftgießerei mit hochwertigen Schriften, kostenlos testbar vor dem Lizenzkauf.
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 Tausende hochwertige Schriften für Web und Desktop, im Creative-Cloud-Abo enthalten.
 
 ## Farben
 
@@ -124,6 +147,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
 - [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
 - [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
+- [Radix Colors](https://www.radix-ui.com/colors) - Ein barrierefreies Farbsystem mit 12-stufigen Skalen für Hintergründe, Rahmen und Text im hellen und dunklen Modus.
+- [UI Colors](https://uicolors.app) - Tailwind-CSS-Farbpaletten-Generator mit Live-Vorschau an Komponenten und Kontrastmatrix.
 
 ## Werkzeuge
 
@@ -135,6 +160,14 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Haikei](https://haikei.app) - Erzeuge einzigartige SVG-Hintergründe, Blobs, Wellen und weitere Design-Assets direkt im Browser.
 - [ray.so](https://ray.so) - Verwandelt Code-Snippets in schöne, teilbare Bilder – von den Machern von Raycast.
 - [tldraw](https://www.tldraw.com) - Ein kollaboratives, unendliches Whiteboard zum Skizzieren von Diagrammen, Wireframes und Ideen.
+- [Motion](https://motion.dev) - Eine produktionsreife Animationsbibliothek für das Web mit APIs für JavaScript, React und Vue.
+- [Excalidraw](https://excalidraw.com) - Ein virtuelles Whiteboard zum Skizzieren von Diagrammen und Wireframes im Handzeichnungs-Stil.
+- [Squoosh](https://squoosh.app) - Bilder direkt im Browser komprimieren und konvertieren – mit Qualitätsvergleich nebeneinander.
+- [TinyPNG](https://tinypng.com) - Intelligente AVIF-, WebP-, PNG- und JPEG-Komprimierung für schnellere Websites.
+- [Typescale](https://typescale.com) - Eine modulare Typo-Skala an echten Layouts vorschauen und als CSS exportieren.
+- [LottieFiles](https://lottiefiles.com) - Leichtgewichtige Lottie-Animationen erstellen, bearbeiten und ausliefern – mit großer Bibliothek fertiger Animationen.
+- [MagicPattern](https://www.magicpattern.design) - Über 30 Generatoren für Hintergründe, Muster, Verläufe und Mockups – exportierbar als Bild, SVG oder CSS.
+- [IconKitchen](https://icon.kitchen) - App-Icons für Android, iOS und Web erzeugen – mit Live-Vorschau auf Geräten.
 - [Rotato](https://rotato.app) - 💵 3D-Mockup-Bilder und Filme in Minuten.
 - [Spline](https://spline.design) - 💵 Ein Ort zum Entwerfen und Zusammenarbeiten in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
@@ -149,7 +182,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
 - [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Ein wunderschön gesetztes Buch über Typografie für alle, die mit Text arbeiten.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
+- [Every Layout](https://every-layout.dev) - 💵 CSS-Layout neu lernen – anhand einfacher, kombinierbarer und robuster Layout-Primitive.
+- [Practical UI](https://www.practical-ui.com) - 💵 Ein logikgetriebener Ansatz, um intuitive, barrierefreie und schöne Interfaces zu gestalten.
 
 ## Communities
 
@@ -158,4 +194,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Sketchfab](https://sketchfab.com) - Sketchfab ist eine 3D-Asset-Website zum Veröffentlichen, Teilen, Entdecken, Kaufen und Verkaufen von 3D-, VR- und AR-Inhalten.
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
 - [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
+- [Behance](https://www.behance.net) - Adobes Plattform, um kreative Arbeiten zu entdecken und das eigene Portfolio zu veröffentlichen.
+- [Godly](https://godly.website) - Astronomisch gutes Webdesign als Inspiration, täglich kuratiert.
+- [Typewolf](https://www.typewolf.com) - Was in der Typografie angesagt ist: Font-Listen, Lookbooks und Typografie auf echten Websites.
+- [Layers](https://layers.to) - Eine Community, in der Designer ihre UI-Arbeiten teilen – samt Stellenangeboten im Designbereich.
+- [Minimal Gallery](https://minimal.gallery) - Eine kuratierte Galerie aus Liebe zu schönen und funktionalen Websites.
+- [Httpster](https://httpster.net) - Eine Galerie mit Webdesign-Inspiration, die regelmäßig um neue Seiten ergänzt wird.
 - [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,12 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
 - [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
+- [Ark UI](https://ark-ui.com) - Una librería headless con más de 45 componentes accesibles para construir sistemas de diseño que funcionan en React, Vue, Solid y Svelte.
+- [Flowbite](https://flowbite.com) - Una librería de código abierto con más de 600 componentes, secciones y páginas construidos con clases de utilidad de Tailwind CSS y diseñados en Figma.
+- [Tremor](https://tremor.so) - Más de 35 componentes React de código abierto para crear gráficos y paneles, construidos con Tailwind CSS y Radix UI.
+- [Primer](https://primer.style) - El sistema de diseño de GitHub, con componentes React y CSS, Octicons y un kit de marca.
+- [Material Design 3](https://m3.material.io) - El sistema de diseño de código abierto de Google, con guías, componentes y tokens de color y tipografía.
+- [UIBall Loaders](https://uiball.com/loaders) - Cargadores y spinners gratuitos y de código abierto hechos con HTML, CSS y SVG, disponibles como componentes React y web.
 
 ## Iconos
 
@@ -59,6 +65,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
+- [Font Awesome](https://fontawesome.com) - El clásico kit de iconos, con miles de iconos gratuitos y una librería pro más amplia, para la web, escritorio y Figma.
+- [Iconbuddy](https://iconbuddy.com) - Busca más de 300.000 iconos de código abierto de más de 200 colecciones, y edítalos y cópialos en el formato que necesites.
+- [3D Icons](https://3dicons.co) - Más de 1.500 renders de iconos 3D hechos a mano, gratuitos y de código abierto.
+- [Pixelarticons](https://pixelarticons.com) - Más de 4.600 iconos de pixel art hechos a mano en una cuadrícula de 24×24, en cuatro estilos.
 
 ## Ilustraciones
 
@@ -74,9 +84,15 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
 - [Blush](https://blush.design) - Ilustraciones personalizables gratuitas con Plugin de Figma. Crea, edita y usa ilustraciones en tus diseños.
 - [Open Peeps](https://www.openpeeps.com) - Una librería de ilustraciones dibujadas a mano para crear escenas de personas. Puedes usarlas en ilustración de productos, marketing, cómics y más.
+- [Open Doodles](https://www.opendoodles.com) - Un conjunto gratuito de ilustraciones dibujadas a mano y de código abierto que puedes recolorear y remezclar.
+- [illlustrations.co](https://illlustrations.co) - Un kit de ilustraciones de código abierto con más de 120 ilustraciones en AI, SVG, PNG, EPS y Figma, gratis para uso personal y comercial.
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - Ilustraciones gratuitas en varios estilos, con colores personalizables y descarga en SVG o PNG.
 
 ## Plantillas
 
+- [Vercel Templates](https://vercel.com/templates) - Plantillas listas para desplegar para los principales frameworks, de Vercel y la comunidad.
+- [Astro Themes](https://astro.build/themes/) - Temas y plantillas de inicio para sitios Astro, desde plantillas open source gratuitas hasta premium.
+- [Landingfolio](https://www.landingfolio.com) - Inspiración curada de landing pages, además de componentes y plantillas para Tailwind, Webflow y Figma.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Componentes y plantillas hermosamente diseñados y expertamente elaborados, construidos por los creadores de Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Plantillas modernas y minimalistas para construir tu próximo producto. Construidas con React, NextJS, TailwindCSS, Framer Motion y Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
@@ -94,8 +110,12 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Little Visuals](https://littlevisuals.co) - Imágenes gratuitas de alta resolución. Úsalas como quieras - gratis para uso comercial.
 - [UI Faces](https://uifaces.co) - Avatares gratuitos generados por IA para tus proyectos creativos.
 - [Nappy](https://nappy.co) - Hermosas fotos en alta resolución de personas negras y morenas, gratis para uso personal y comercial.
+- [Kaboompics](https://kaboompics.com) - Fotos de stock gratuitas y sesiones fotográficas curadas, con búsqueda por paleta de colores.
+- [Gratisography](https://gratisography.com) - Fotos de stock en alta resolución realmente únicas, normalmente extravagantes y siempre gratuitas.
 - [Deposit Photos](https://depositphotos.com) - 💵 Fotos de stock libres de derechos, imágenes vectoriales, videos y música.
 - [Freepik](https://www.freepik.com) - 💵 Millones de vectores gratuitos, archivos PSD, fotos e imágenes generadas por IA. Recursos premium para tus proyectos creativos.
+- [Rawpixel](https://www.rawpixel.com) - 💵 Fotos, arte vintage de dominio público, mockups y recursos de diseño.
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 Fotos y vídeos de stock que mantienen tu marca culturalmente relevante.
 
 ## Fuentes
 
@@ -103,11 +123,14 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Inter](https://rsms.me/inter/) - Una familia de fuentes variable para interfaces de texto.
 - [Fontshare](https://www.fontshare.com) - Un servicio de fuentes gratuito de Indian Type Foundry, con tipografías de calidad licenciadas para uso personal y comercial.
 - [Uncut](https://uncut.wtf) - Una biblioteca curada de tipografías contemporáneas de código abierto, gratis para descargar y usar.
+- [Fontsource](https://fontsource.org) - Autoaloja fuentes de código abierto como paquetes npm, con vista previa de más de 2.000 familias.
+- [Modern Font Stacks](https://modernfontstacks.com) - Pilas de fuentes del sistema organizadas por clasificación tipográfica: sin descargas, sin saltos de layout, renderizado instantáneo.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Compra productos y bienes de calidad y curados.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
 - [Klim](https://klim.co.nz) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Una fundición tipográfica independiente con tipografías de alta calidad, gratis para probar antes de licenciarlas.
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 Miles de fuentes de alta calidad para web y escritorio, incluidas con un plan de Creative Cloud.
 
 ## Colores
 
@@ -124,6 +147,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
 - [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
 - [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un sistema de color accesible con escalas de 12 pasos diseñadas para fondos, bordes y texto en modo claro y oscuro.
+- [UI Colors](https://uicolors.app) - Generador de paletas de color para Tailwind CSS con vista previa en componentes reales y matriz de contraste.
 
 ## Herramientas
 
@@ -135,6 +160,14 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Haikei](https://haikei.app) - Genera fondos SVG únicos, blobs, ondas y otros recursos de diseño directamente en el navegador.
 - [ray.so](https://ray.so) - Convierte fragmentos de código en imágenes bonitas listas para compartir, de los creadores de Raycast.
 - [tldraw](https://www.tldraw.com) - Una pizarra infinita colaborativa para bocetar diagramas, wireframes e ideas.
+- [Motion](https://motion.dev) - Una librería de animación de nivel producción para la web, con APIs para JavaScript, React y Vue.
+- [Excalidraw](https://excalidraw.com) - Una pizarra virtual para bocetar diagramas y wireframes con estilo dibujado a mano.
+- [Squoosh](https://squoosh.app) - Comprime y convierte imágenes directamente en el navegador, con comparación de calidad lado a lado.
+- [TinyPNG](https://tinypng.com) - Compresión inteligente de AVIF, WebP, PNG y JPEG para sitios web más rápidos.
+- [Typescale](https://typescale.com) - Previsualiza una escala tipográfica modular en maquetas reales y expórtala como CSS.
+- [LottieFiles](https://lottiefiles.com) - Crea, edita y publica animaciones Lottie ligeras, con una gran biblioteca de animaciones listas para usar.
+- [MagicPattern](https://www.magicpattern.design) - Más de 30 generadores de fondos, patrones, degradados y mockups, exportables como imagen, SVG o CSS.
+- [IconKitchen](https://icon.kitchen) - Genera iconos de aplicación para Android, iOS y la web, con vista previa en dispositivos en tiempo real.
 - [Rotato](https://rotato.app) - 💵 Imágenes mockup 3D y películas en minutos.
 - [Spline](https://spline.design) - 💵 Un lugar para diseñar y colaborar en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
@@ -149,7 +182,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Un libro bellamente compuesto sobre tipografía para todo el que trabaja con texto.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
+- [Every Layout](https://every-layout.dev) - 💵 Reaprende el layout en CSS mediante un conjunto de primitivas de diseño simples, componibles y resilientes.
+- [Practical UI](https://www.practical-ui.com) - 💵 Un enfoque basado en la lógica para diseñar interfaces intuitivas, accesibles y bonitas.
 
 ## Comunidades
 
@@ -158,4 +194,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Sketchfab](https://sketchfab.com) - Sketchfab es un sitio web de recursos 3D usado para publicar, compartir, descubrir, comprar y vender contenido 3D, VR y AR.
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
 - [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
+- [Behance](https://www.behance.net) - La plataforma de Adobe para descubrir trabajo creativo y publicar tu propio portafolio.
+- [Godly](https://godly.website) - Inspiración de diseño web astronómicamente buena, curada a diario.
+- [Typewolf](https://www.typewolf.com) - Lo que es tendencia en tipografía: listas de fuentes, lookbooks y tipografía en sitios reales.
+- [Layers](https://layers.to) - Una comunidad donde los diseñadores comparten su trabajo de UI, junto con ofertas de empleo de diseño.
+- [Minimal Gallery](https://minimal.gallery) - Una galería curada por amor a los sitios web bonitos y funcionales.
+- [Httpster](https://httpster.net) - Una galería de inspiración de diseño web, actualizada regularmente con nuevos sitios.
 - [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,6 +40,12 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
 - [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
+- [Ark UI](https://ark-ui.com) - Une bibliothèque headless de plus de 45 composants accessibles pour créer des design systems fonctionnant avec React, Vue, Solid et Svelte.
+- [Flowbite](https://flowbite.com) - Une bibliothèque open source de plus de 600 composants, sections et pages construits avec les classes utilitaires de Tailwind CSS et conçus dans Figma.
+- [Tremor](https://tremor.so) - Plus de 35 composants React open source pour créer des graphiques et des tableaux de bord, construits avec Tailwind CSS et Radix UI.
+- [Primer](https://primer.style) - Le design system de GitHub, avec des composants React et CSS, Octicons et une boîte à outils de marque.
+- [Material Design 3](https://m3.material.io) - Le design system open source de Google, avec des recommandations, des composants et des tokens de couleur et de typographie.
+- [UIBall Loaders](https://uiball.com/loaders) - Loaders et spinners gratuits et open source réalisés en HTML, CSS et SVG, disponibles en composants React et web.
 
 ## Icônes
 
@@ -59,6 +65,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
+- [Font Awesome](https://fontawesome.com) - La boîte à outils d'icônes classique, avec des milliers d'icônes gratuites et une bibliothèque pro plus large, pour le web, le bureau et Figma.
+- [Iconbuddy](https://iconbuddy.com) - Recherchez plus de 300 000 icônes open source issues de plus de 200 collections, puis modifiez-les et copiez-les au format voulu.
+- [3D Icons](https://3dicons.co) - Plus de 1 500 rendus d'icônes 3D faits à la main, gratuits et open source.
+- [Pixelarticons](https://pixelarticons.com) - Plus de 4 600 icônes en pixel art faites à la main sur une grille 24×24, en quatre styles.
 
 ## Illustrations
 
@@ -74,9 +84,15 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
 - [Blush](https://blush.design) - Illustrations personnalisables gratuites avec Plugin Figma. Créez, éditez et utilisez des illustrations dans vos designs.
 - [Open Peeps](https://www.openpeeps.com) - Une bibliothèque d'illustrations dessinées à la main pour créer des scènes de personnes. Vous pouvez les utiliser dans l'illustration de produit, marketing, bandes dessinées et plus.
+- [Open Doodles](https://www.opendoodles.com) - Un ensemble gratuit et open source d'illustrations dessinées à la main, que vous pouvez recolorer et remixer.
+- [illlustrations.co](https://illlustrations.co) - Un kit d'illustrations open source de plus de 120 illustrations en AI, SVG, PNG, EPS et Figma, gratuit pour un usage personnel et commercial.
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - Des illustrations gratuites dans plusieurs styles, recolorables et téléchargeables en SVG ou PNG.
 
 ## Modèles
 
+- [Vercel Templates](https://vercel.com/templates) - Des starters prêts à déployer pour tous les principaux frameworks, proposés par Vercel et la communauté.
+- [Astro Themes](https://astro.build/themes/) - Des thèmes et starters pour les sites Astro, des modèles open source gratuits aux modèles premium.
+- [Landingfolio](https://www.landingfolio.com) - Inspiration de landing pages sélectionnée, ainsi que des composants et modèles pour Tailwind, Webflow et Figma.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Composants et modèles magnifiquement conçus et expertement créés, construits par les créateurs de Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modèles modernes et minimalistes pour construire votre prochain produit. Construits avec React, NextJS, TailwindCSS, Framer Motion et Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
@@ -94,8 +110,12 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Little Visuals](https://littlevisuals.co) - Images gratuites, haute résolution. Utilisez-les comme vous voulez - gratuit pour usage commercial.
 - [UI Faces](https://uifaces.co) - Avatars gratuits générés par IA pour vos projets créatifs.
 - [Nappy](https://nappy.co) - De belles photos haute résolution de personnes noires et métisses, gratuites pour un usage personnel et commercial.
+- [Kaboompics](https://kaboompics.com) - Photos libres de droits gratuites et séries photo sélectionnées, avec recherche par palette de couleurs.
+- [Gratisography](https://gratisography.com) - Des photos haute résolution vraiment uniques, souvent décalées, et toujours gratuites.
 - [Deposit Photos](https://depositphotos.com) - 💵 Photos stock libres de droits, images vectorielles, vidéos et musique.
 - [Freepik](https://www.freepik.com) - 💵 Millions de vecteurs gratuits, fichiers PSD, photos et images générées par IA. Ressources premium pour vos projets créatifs.
+- [Rawpixel](https://www.rawpixel.com) - 💵 Photos, œuvres vintage du domaine public, mockups et ressources de design.
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 Photos et vidéos de stock pour garder votre marque culturellement pertinente.
 
 ## Polices
 
@@ -103,11 +123,14 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Inter](https://rsms.me/inter/) - Une famille de polices variable pour interfaces texte.
 - [Fontshare](https://www.fontshare.com) - Un service de polices gratuit de l'Indian Type Foundry, avec des typographies de qualité sous licence personnelle et commerciale.
 - [Uncut](https://uncut.wtf) - Une bibliothèque sélectionnée de typographies contemporaines open source, libres de téléchargement et d'utilisation.
+- [Fontsource](https://fontsource.org) - Auto-hébergez des polices open source sous forme de paquets npm, avec un aperçu de plus de 2 000 familles.
+- [Modern Font Stacks](https://modernfontstacks.com) - Des piles de polices système organisées par classification typographique : aucun téléchargement, aucun décalage de mise en page, rendu instantané.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Achetez des produits et biens de qualité, sélectionnés.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
 - [Klim](https://klim.co.nz) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Une fonderie typographique indépendante aux caractères de haute qualité, gratuits à essayer avant l'achat de licence.
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 Des milliers de polices de haute qualité pour le web et le bureau, incluses dans un abonnement Creative Cloud.
 
 ## Couleurs
 
@@ -124,6 +147,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
 - [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
 - [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un système de couleurs accessible avec des échelles en 12 paliers pensées pour les fonds, bordures et textes en modes clair et sombre.
+- [UI Colors](https://uicolors.app) - Générateur de palettes de couleurs Tailwind CSS avec aperçu en direct sur des composants et matrice de contraste.
 
 ## Outils
 
@@ -135,6 +160,14 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Haikei](https://haikei.app) - Générez des arrière-plans SVG uniques, blobs, vagues et autres ressources de design directement dans le navigateur.
 - [ray.so](https://ray.so) - Transformez des extraits de code en belles images prêtes à partager, par les créateurs de Raycast.
 - [tldraw](https://www.tldraw.com) - Un tableau blanc infini et collaboratif pour esquisser diagrammes, wireframes et idées.
+- [Motion](https://motion.dev) - Une bibliothèque d'animation de qualité production pour le web, avec des API pour JavaScript, React et Vue.
+- [Excalidraw](https://excalidraw.com) - Un tableau blanc virtuel pour esquisser des diagrammes et wireframes au style dessiné à la main.
+- [Squoosh](https://squoosh.app) - Compressez et convertissez des images directement dans le navigateur, avec une comparaison de qualité côte à côte.
+- [TinyPNG](https://tinypng.com) - Compression intelligente AVIF, WebP, PNG et JPEG pour des sites plus rapides.
+- [Typescale](https://typescale.com) - Prévisualisez une échelle typographique modulaire sur de vraies mises en page et exportez-la en CSS.
+- [LottieFiles](https://lottiefiles.com) - Créez, modifiez et publiez des animations Lottie légères, avec une vaste bibliothèque prête à l'emploi.
+- [MagicPattern](https://www.magicpattern.design) - Plus de 30 générateurs de fonds, motifs, dégradés et mockups, exportables en image, SVG ou CSS.
+- [IconKitchen](https://icon.kitchen) - Générez des icônes d'application pour Android, iOS et le web, avec un aperçu en direct sur appareil.
 - [Rotato](https://rotato.app) - 💵 Images de maquette 3D et films en minutes.
 - [Spline](https://spline.design) - 💵 Un lieu pour concevoir et collaborer en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
@@ -149,7 +182,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Un livre magnifiquement composé sur la typographie, pour tous ceux qui travaillent avec du texte.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
+- [Every Layout](https://every-layout.dev) - 💵 Réapprenez la mise en page CSS grâce à un ensemble de primitives simples, composables et résilientes.
+- [Practical UI](https://www.practical-ui.com) - 💵 Une approche fondée sur la logique pour concevoir des interfaces intuitives, accessibles et esthétiques.
 
 ## Communautés
 
@@ -158,4 +194,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Sketchfab](https://sketchfab.com) - Sketchfab est un site web d'actifs 3D utilisé pour publier, partager, découvrir, acheter et vendre du contenu 3D, VR et AR.
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
 - [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
+- [Behance](https://www.behance.net) - La plateforme d'Adobe pour découvrir des travaux créatifs et publier son propre portfolio.
+- [Godly](https://godly.website) - Une inspiration en design web astronomiquement bonne, sélectionnée chaque jour.
+- [Typewolf](https://www.typewolf.com) - Les tendances typographiques : listes de polices, lookbooks et typographie sur de vrais sites.
+- [Layers](https://layers.to) - Une communauté où les designers partagent leurs travaux d'UI, avec aussi des offres d'emploi en design.
+- [Minimal Gallery](https://minimal.gallery) - Une galerie sélectionnée par amour des sites beaux et fonctionnels.
+- [Httpster](https://httpster.net) - Une galerie d'inspiration en design web, régulièrement enrichie de nouveaux sites.
 - [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,12 @@
 - [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
 - [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
 - [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
+- [Ark UI](https://ark-ui.com) - React、Vue、Solid、Svelte で動作するデザインシステムを構築するための、45 以上のアクセシブルなコンポーネントを備えたヘッドレスライブラリ。
+- [Flowbite](https://flowbite.com) - Tailwind CSS のユーティリティクラスで構築され、Figma でデザインされた 600 以上の UI コンポーネント、セクション、ページのオープンソースライブラリ。
+- [Tremor](https://tremor.so) - Tailwind CSS と Radix UI で構築された、チャートやダッシュボードを作るための 35 以上のオープンソース React コンポーネント。
+- [Primer](https://primer.style) - React と CSS のコンポーネント、Octicons、ブランドツールキットを備えた GitHub のデザインシステム。
+- [Material Design 3](https://m3.material.io) - ガイドライン、コンポーネント、カラーとタイポグラフィのトークンを備えた Google のオープンソースデザインシステム。
+- [UIBall Loaders](https://uiball.com/loaders) - HTML、CSS、SVG で作られた無料でオープンソースのローダーとスピナー。React と Web Components として利用できます。
 
 ## アイコン
 
@@ -59,6 +65,10 @@
 - [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
+- [Font Awesome](https://fontawesome.com) - 数千の無料アイコンと、より大規模なプロ版ライブラリを備えた定番のアイコンツールキット。Web、デスクトップ、Figma に対応。
+- [Iconbuddy](https://iconbuddy.com) - 200 以上のセットから 30 万を超えるオープンソースアイコンを検索し、必要な形式で編集・コピーできます。
+- [3D Icons](https://3dicons.co) - 手作りの 3D アイコンレンダー 1,500 点以上。無料かつオープンソース。
+- [Pixelarticons](https://pixelarticons.com) - 24×24 グリッド上で手作りされた 4,600 以上のピクセルアートアイコン。4 つのスタイルを用意。
 
 ## イラスト
 
@@ -74,9 +84,15 @@
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
 - [Blush](https://blush.design) - Figma プラグイン付きの無料カスタマイズ可能イラスト。デザインでイラストを作成、編集、使用できます。
 - [Open Peeps](https://www.openpeeps.com) - 人々のシーンを作成するための手描きイラストライブラリ。製品イラスト、マーケティング、コミックなどで使用できます。
+- [Open Doodles](https://www.opendoodles.com) - 色替えやリミックスが自由にできる、無料でオープンソースの手描きイラストセット。
+- [illlustrations.co](https://illlustrations.co) - AI、SVG、PNG、EPS、Figma 形式で 120 点以上を収録したオープンソースのイラストキット。個人・商用ともに無料。
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - 複数のスタイルから選べる無料イラスト。色を変更して SVG または PNG でダウンロードできます。
 
 ## テンプレート
 
+- [Vercel Templates](https://vercel.com/templates) - Vercel とコミュニティによる、主要フレームワーク向けのすぐデプロイできるスターターテンプレート。
+- [Astro Themes](https://astro.build/themes/) - 無料のオープンソーステンプレートから有料テーマまで揃った、Astro サイト向けのテーマとスターター。
+- [Landingfolio](https://www.landingfolio.com) - 厳選されたランディングページのインスピレーションに加え、Tailwind、Webflow、Figma 向けのコンポーネントとテンプレートを提供。
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 Tailwind CSS の制作者による美しくデザインされ、専門的に作られたコンポーネントとテンプレート。
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 次の製品を構築するためのモダンでミニマリストなテンプレート。React、NextJS、TailwindCSS、Framer Motion、TypeScript で構築。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
@@ -94,8 +110,12 @@
 - [Little Visuals](https://littlevisuals.co) - 無料、高解像度画像。お好みに応じて使用 - 商用利用無料。
 - [UI Faces](https://uifaces.co) - クリエイティブプロジェクト用の無料 AI 生成アバター。
 - [Nappy](https://nappy.co) - 黒人・褐色の肌の人々を撮影した高解像度の写真。個人利用・商用利用ともに無料。
+- [Kaboompics](https://kaboompics.com) - 無料のストック写真と厳選されたフォトシュート。カラーパレットからも検索できます。
+- [Gratisography](https://gratisography.com) - 個性的でユーモアにあふれ、常に無料の高解像度ストック写真。
 - [Deposit Photos](https://depositphotos.com) - 💵 ロイヤリティフリーストック写真、ベクター画像、動画、音楽。
 - [Freepik](https://www.freepik.com) - 💵 数百万の無料ベクター、PSD ファイル、写真、AI 生成画像。クリエイティブプロジェクト用のプレミアムリソース。
+- [Rawpixel](https://www.rawpixel.com) - 💵 写真、パブリックドメインのヴィンテージアート、モックアップ、デザイン素材。
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 ブランドを時代の空気に合わせ続けるためのストック写真と動画。
 
 ## フォント
 
@@ -103,11 +123,14 @@
 - [Inter](https://rsms.me/inter/) - テキストインターフェース用の可変フォントファミリー。
 - [Fontshare](https://www.fontshare.com) - Indian Type Foundry による無料フォントサービス。個人利用・商用利用が可能な高品質書体を提供。
 - [Uncut](https://uncut.wtf) - 現代的なオープンソース書体を厳選したライブラリ。無料でダウンロードして利用可能。
+- [Fontsource](https://fontsource.org) - オープンソースフォントを npm パッケージとしてセルフホスト。2,000 以上のファミリーをプレビューできます。
+- [Modern Font Stacks](https://modernfontstacks.com) - 書体分類ごとに整理されたシステムフォントスタック。ダウンロード不要、レイアウトシフトなし、即座に描画されます。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 厳選された品質の商品と製品をショッピング。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
 - [Klim](https://klim.co.nz) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 高品質な書体を手がける独立系フォントファウンドリ。ライセンス購入前に無料で試用可能。
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 Creative Cloud プランに含まれる、Web とデスクトップ向けの高品質フォント数千種。
 
 ## 色
 
@@ -124,6 +147,8 @@
 - [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
 - [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
+- [Radix Colors](https://www.radix-ui.com/colors) - ライトモードとダークモードの背景・境界線・テキスト向けに設計された、12 段階スケールのアクセシブルなカラーシステム。
+- [UI Colors](https://uicolors.app) - コンポーネント上でのライブプレビューとコントラストマトリクスを備えた Tailwind CSS カラーパレットジェネレーター。
 
 ## ツール
 
@@ -135,6 +160,14 @@
 - [Haikei](https://haikei.app) - ブラウザ上でユニークな SVG の背景、ブロブ、波などのデザインアセットを生成。
 - [ray.so](https://ray.so) - コードスニペットを共有しやすい美しい画像に変換。Raycast チームによるツール。
 - [tldraw](https://www.tldraw.com) - 図やワイヤーフレーム、アイデアをスケッチできる、共同編集対応の無限ホワイトボード。
+- [Motion](https://motion.dev) - JavaScript、React、Vue 向けの API を備えた、本番運用に耐える Web アニメーションライブラリ。
+- [Excalidraw](https://excalidraw.com) - 手描き風の図やワイヤーフレームをスケッチできるバーチャルホワイトボード。
+- [Squoosh](https://squoosh.app) - ブラウザー上で画像を圧縮・変換し、画質を左右で見比べられるツール。
+- [TinyPNG](https://tinypng.com) - サイトを高速化するための、AVIF・WebP・PNG・JPEG のスマートな圧縮ツール。
+- [Typescale](https://typescale.com) - モジュラータイプスケールを実際のレイアウトでプレビューし、CSS として書き出せます。
+- [LottieFiles](https://lottiefiles.com) - 軽量な Lottie アニメーションの作成・編集・実装ができ、既製アニメーションの大規模ライブラリも利用できます。
+- [MagicPattern](https://www.magicpattern.design) - 背景、パターン、グラデーション、モックアップを作れる 30 以上のジェネレーター。画像・SVG・CSS で書き出せます。
+- [IconKitchen](https://icon.kitchen) - Android、iOS、Web 向けのアプリアイコンを、実機プレビュー付きで生成できます。
 - [Rotato](https://rotato.app) - 💵 数分で 3D モックアップ画像と動画。
 - [Spline](https://spline.design) - 💵 3D でデザインし協力する場所。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
@@ -149,7 +182,10 @@
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
 - [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
+- [Butterick's Practical Typography](https://practicaltypography.com) - テキストを扱うすべての人に向けた、美しく組版されたタイポグラフィの本。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
+- [Every Layout](https://every-layout.dev) - 💵 シンプルで組み合わせやすく壊れにくいレイアウトプリミティブを通じて、CSS レイアウトを学び直す一冊。
+- [Practical UI](https://www.practical-ui.com) - 💵 直感的でアクセシブル、そして美しいインターフェースを設計するための、論理に基づいたアプローチ。
 
 ## コミュニティ
 
@@ -158,4 +194,10 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab は 3D、VR、AR コンテンツを公開、共有、発見、売買するために使用される 3D アセットウェブサイト。
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
 - [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
+- [Behance](https://www.behance.net) - クリエイティブな作品を発見し、自分のポートフォリオを公開できる Adobe のプラットフォーム。
+- [Godly](https://godly.website) - 毎日厳選される、飛び抜けて優れた Web デザインのインスピレーション集。
+- [Typewolf](https://www.typewolf.com) - フォントリストやルックブック、実在のサイトで使われている書体など、タイポグラフィのトレンドを紹介。
+- [Layers](https://layers.to) - デザイナーが UI 作品を共有するコミュニティ。デザイン職の求人情報も掲載。
+- [Minimal Gallery](https://minimal.gallery) - 美しく機能的な Web サイトを愛でるための、厳選されたギャラリー。
+- [Httpster](https://httpster.net) - 新しいサイトが定期的に追加される、Web デザインのインスピレーションギャラリー。
 - [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
 - [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
 - [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
+- [Ark UI](https://ark-ui.com) - A headless library of 45+ accessible components for building design systems that work across React, Vue, Solid and Svelte.
+- [Flowbite](https://flowbite.com) - An open-source library of 600+ UI components, sections and pages built with Tailwind CSS utility classes and designed in Figma.
+- [Tremor](https://tremor.so) - 35+ open-source React components for building charts and dashboards, built with Tailwind CSS and Radix UI.
+- [Primer](https://primer.style) - GitHub's design system, with React and CSS components, Octicons and a brand toolkit.
+- [Material Design 3](https://m3.material.io) - Google's open-source design system, with guidelines, components and color and typography tokens.
+- [UIBall Loaders](https://uiball.com/loaders) - Free, open-source loaders and spinners built with HTML, CSS and SVG, available as React and web components.
 
 ## Icons
 
@@ -59,6 +65,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
+- [Font Awesome](https://fontawesome.com) - The classic icon toolkit, with thousands of free icons plus a larger pro library, for the web, desktop and Figma.
+- [Iconbuddy](https://iconbuddy.com) - Search 300,000+ open-source icons from 200+ sets, then edit and copy them in the format you need.
+- [3D Icons](https://3dicons.co) - 1,500+ hand-made 3D icon renders, free and open source.
+- [Pixelarticons](https://pixelarticons.com) - 4,600+ hand-crafted pixel art icons on a 24×24 grid, in four styles.
 
 ## Illustrations
 
@@ -74,9 +84,15 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
 - [Blush](https://blush.design) - Free customizable illustrations with Figma Plugin. Create, edit, and use illustrations in your designs.
 - [Open Peeps](https://www.openpeeps.com) - A hand-drawn illustration library to create scenes of people. You can use them in product illustration, marketing, comics, and more.
+- [Open Doodles](https://www.opendoodles.com) - A free set of open-source hand-drawn illustrations you can recolor and remix.
+- [illlustrations.co](https://illlustrations.co) - An open-source illustration kit of 120+ illustrations in AI, SVG, PNG, EPS and Figma, free for personal and commercial use.
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - Free illustrations in several styles, recolorable and downloadable as SVG or PNG.
 
 ## Templates
 
+- [Vercel Templates](https://vercel.com/templates) - Pre-built, deployable starters for every major framework, from Vercel and the community.
+- [Astro Themes](https://astro.build/themes/) - Themes and starters for Astro sites, from free open-source templates to premium ones.
+- [Landingfolio](https://www.landingfolio.com) - Curated landing page inspiration, plus components and templates for Tailwind, Webflow and Figma.
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵Beautifully designed, expertly crafted components and templates, built by the makers of Tailwind CSS.
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modern and minimalist templates for building your next product. Built with React, NextJS, TailwindCSS, Framer Motion and Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
@@ -94,8 +110,12 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Little Visuals](https://littlevisuals.co) - Free, high resolution images. Use them anyway you want - free for commercial use.
 - [UI Faces](https://uifaces.co) - Free AI-generated avatars for your creative projects.
 - [Nappy](https://nappy.co) - Beautiful high-resolution photos of Black and Brown people, free for personal and commercial use.
+- [Kaboompics](https://kaboompics.com) - Free stock photos and curated photoshoots, searchable by color palette.
+- [Gratisography](https://gratisography.com) - Truly unique, usually whimsical, always free high-resolution stock photos.
 - [Deposit Photos](https://depositphotos.com) - 💵 Royalty-free Stock Photos, Vector Images, Videos and Music.
 - [Freepik](https://www.freepik.com) - 💵 Millions of free vectors, PSD files, photos and AI-generated images. Premium resources for your creative projects.
+- [Rawpixel](https://www.rawpixel.com) - 💵 Photos, vintage public-domain artwork, mockups and design assets.
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 Stock photos and video that keep your brand culturally relevant.
 
 ## Fonts
 
@@ -103,11 +123,14 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Inter](https://rsms.me/inter/) - A variable font family for text interfaces.
 - [Fontshare](https://www.fontshare.com) - A free font service from the Indian Type Foundry, with quality typefaces licensed for personal and commercial use.
 - [Uncut](https://uncut.wtf) - A curated library of contemporary open-source typefaces, free to download and use.
+- [Fontsource](https://fontsource.org) - Self-host open-source fonts as npm packages, with previews for 2,000+ families.
+- [Modern Font Stacks](https://modernfontstacks.com) - System font stacks organized by typeface classification — no downloads, no layout shifts, instant renders.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Shop quality, curated goods and products.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Shop quality, curated fonts from indie font foundries.
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
 - [Klim](https://klim.co.nz) - 💵 Shop quality, curated fonts from indie font foundries.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 An independent type foundry with high-quality typefaces, free to try before you license them.
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 Thousands of high-quality fonts for web and desktop, included with a Creative Cloud plan.
 
 ## Colors
 
@@ -124,6 +147,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
 - [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
 - [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
+- [Radix Colors](https://www.radix-ui.com/colors) - An accessible color system of 12-step scales designed for backgrounds, borders and text in light and dark mode.
+- [UI Colors](https://uicolors.app) - Tailwind CSS color palette generator with live component previews and a contrast matrix.
 
 ## Tools
 
@@ -135,6 +160,14 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Haikei](https://haikei.app) - Generate unique SVG backgrounds, blobs, waves and other design assets right in the browser.
 - [ray.so](https://ray.so) - Turn code snippets into beautiful images ready to share, by the makers of Raycast.
 - [tldraw](https://www.tldraw.com) - A collaborative infinite whiteboard for sketching diagrams, wireframes and ideas.
+- [Motion](https://motion.dev) - A production-grade animation library for the web, with APIs for JavaScript, React and Vue.
+- [Excalidraw](https://excalidraw.com) - A virtual whiteboard for sketching hand-drawn style diagrams and wireframes.
+- [Squoosh](https://squoosh.app) - Compress and convert images right in the browser, with a side-by-side quality comparison.
+- [TinyPNG](https://tinypng.com) - Smart AVIF, WebP, PNG and JPEG compression for faster websites.
+- [Typescale](https://typescale.com) - Preview a modular type scale on real layouts and export it as CSS.
+- [LottieFiles](https://lottiefiles.com) - Create, edit and ship lightweight Lottie animations, with a large library of ready-made ones.
+- [MagicPattern](https://www.magicpattern.design) - 30+ generators for backgrounds, patterns, gradients and mockups, exported as image, SVG or CSS.
+- [IconKitchen](https://icon.kitchen) - Generate app icons for Android, iOS and the web, with live device previews.
 - [Rotato](https://rotato.app) - 💵 3D mockup images and movies in minutes.
 - [Spline](https://spline.design) - 💵 A place to design and collaborate in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
@@ -149,7 +182,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
+- [Butterick's Practical Typography](https://practicaltypography.com) - A beautifully typeset book on typography for everyone who works with text.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
+- [Every Layout](https://every-layout.dev) - 💵 Relearn CSS layout through a set of simple, composable and resilient layout primitives.
+- [Practical UI](https://www.practical-ui.com) - 💵 A logic-driven approach to designing intuitive, accessible and beautiful interfaces.
 
 ## Communities
 
@@ -158,4 +194,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Sketchfab](https://sketchfab.com) - Sketchfab is a 3D asset website used to publish, share, discover, buy and sell 3D, VR and AR content.
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
 - [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
+- [Behance](https://www.behance.net) - Adobe's platform for discovering creative work and publishing your own portfolio.
+- [Godly](https://godly.website) - Astronomically good web design inspiration, curated daily.
+- [Typewolf](https://www.typewolf.com) - What's trending in type: font lists, lookbooks and typography seen on real websites.
+- [Layers](https://layers.to) - A community where designers share their UI work, alongside design job listings.
+- [Minimal Gallery](https://minimal.gallery) - A curated gallery for the love of beautiful and functional websites.
+- [Httpster](https://httpster.net) - A gallery of website design inspiration, refreshed with new sites regularly.
 - [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,12 @@
 - [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
 - [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
 - [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
+- [Ark UI](https://ark-ui.com) - 包含 45+ 个无障碍组件的无样式组件库，可用于构建同时支持 React、Vue、Solid 和 Svelte 的设计系统。
+- [Flowbite](https://flowbite.com) - 开源的 Tailwind CSS 组件库，提供 600+ 个 UI 组件、区块和页面，并附带 Figma 设计文件。
+- [Tremor](https://tremor.so) - 35+ 个开源 React 组件，用于构建图表和仪表盘，基于 Tailwind CSS 和 Radix UI 构建。
+- [Primer](https://primer.style) - GitHub 的设计系统，包含 React 与 CSS 组件、Octicons 图标以及品牌工具包。
+- [Material Design 3](https://m3.material.io) - Google 的开源设计系统，提供设计规范、组件以及颜色和排版令牌。
+- [UIBall Loaders](https://uiball.com/loaders) - 免费开源的加载动画与 loading 指示器，使用 HTML、CSS 和 SVG 构建，提供 React 和 Web Components 版本。
 
 ## 图标
 
@@ -60,6 +66,10 @@
 
 - [React Icons](https://react-icons.github.io/react-icons/) - 使用 react-icons 轻松在 React 项目中包含流行图标。
 - [Iconoir](https://iconoir.com) - 1600+ 免费开源的高质量 SVG 图标，支持 SVG、Font、React、React Native、Flutter、Figma 和 Framer。
+- [Font Awesome](https://fontawesome.com) - 经典的图标工具集，提供数千个免费图标以及更庞大的专业版图标库，支持 Web、桌面端和 Figma。
+- [Iconbuddy](https://iconbuddy.com) - 在 200+ 个图标集、30 万+ 开源图标中搜索，并按所需格式编辑和复制。
+- [3D Icons](https://3dicons.co) - 1500+ 个手工制作的 3D 图标渲染素材，免费且开源。
+- [Pixelarticons](https://pixelarticons.com) - 4600+ 个手工绘制的像素风图标，基于 24×24 网格，提供四种风格。
 
 ## 插图
 
@@ -75,9 +85,15 @@
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
 - [Blush](https://blush.design) - 免费可定制插图，带 Figma 插件。在您的设计中创建、编辑和使用插图。
 - [Open Peeps](https://www.openpeeps.com) - 手绘人物插图库，用于创建人物场景。可用于产品插图、营销、漫画等。
+- [Open Doodles](https://www.opendoodles.com) - 一套免费开源的手绘插画，可自由换色和二次创作。
+- [illlustrations.co](https://illlustrations.co) - 开源插画套件，包含 120+ 张插画，提供 AI、SVG、PNG、EPS 和 Figma 格式，可免费用于个人和商业项目。
+- [ManyPixels Gallery](https://www.manypixels.co/gallery) - 多种风格的免费插画，可自定义配色并下载为 SVG 或 PNG。
 
 ## 模板
 
+- [Vercel Templates](https://vercel.com/templates) - 由 Vercel 和社区提供的可一键部署的预置模板，覆盖各主流框架。
+- [Astro Themes](https://astro.build/themes/) - 面向 Astro 站点的主题与启动模板，涵盖免费开源模板和付费高级模板。
+- [Landingfolio](https://www.landingfolio.com) - 精选的落地页设计灵感，同时提供 Tailwind、Webflow 和 Figma 的组件与模板。
 - [Tailwind Plus](https://tailwindcss.com/plus) - 💵 精美设计、专业制作的组件和模板，由 Tailwind CSS 的制作者构建。
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 现代和极简的模板，用于构建您的下一个产品。使用 React、NextJS、TailwindCSS、Framer Motion 和 Typescript 构建。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
@@ -95,8 +111,12 @@
 - [Little Visuals](https://littlevisuals.co) - 免费高分辨率图像。可以随意使用 - 免费商用。
 - [UI Faces](https://uifaces.co) - 为您的创意项目提供免费 AI 生成头像。
 - [Nappy](https://nappy.co) - 以黑人和棕色人种为主题的高分辨率精美照片，可免费用于个人和商业项目。
+- [Kaboompics](https://kaboompics.com) - 免费图库照片和精选拍摄合集，支持按配色搜索。
+- [Gratisography](https://gratisography.com) - 独一无二、充满奇思妙想且始终免费的高分辨率图库照片。
 - [Deposit Photos](https://depositphotos.com) - 💵 免费版权库存照片、矢量图像、视频和音乐。
 - [Freepik](https://www.freepik.com) - 💵 数百万免费矢量、PSD 文件、照片和 AI 生成图像。创意项目的优质资源。
+- [Rawpixel](https://www.rawpixel.com) - 💵 照片、公共领域的复古艺术作品、样机和设计素材。
+- [Death to Stock](https://deathtothestockphoto.com) - 💵 让品牌保持时代感的图库照片与视频订阅服务。
 
 ## 字体
 
@@ -104,11 +124,14 @@
 - [Inter](https://rsms.me/inter/) - 一个用于文本界面的可变字体家族。
 - [Fontshare](https://www.fontshare.com) - 来自 Indian Type Foundry 的免费字体服务，提供可用于个人和商业项目的优质字体。
 - [Uncut](https://uncut.wtf) - 精选的当代开源字体库，可免费下载使用。
+- [Fontsource](https://fontsource.org) - 以 npm 包形式自托管开源字体，可预览 2000+ 字体家族。
+- [Modern Font Stacks](https://modernfontstacks.com) - 按字体分类整理的系统字体栈——无需下载、不产生布局偏移、即时渲染。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 购买优质、精选的商品和产品。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
 - [Klim](https://klim.co.nz) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 独立字体工作室出品的高品质字体，购买授权前可免费试用。
+- [Adobe Fonts](https://fonts.adobe.com) - 💵 数千款面向 Web 和桌面端的高质量字体，包含在 Creative Cloud 订阅中。
 
 ## 颜色
 
@@ -125,6 +148,8 @@
 - [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
 - [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
+- [Radix Colors](https://www.radix-ui.com/colors) - 无障碍色彩系统，采用 12 级色阶，为浅色和深色模式下的背景、边框与文字而设计。
+- [UI Colors](https://uicolors.app) - Tailwind CSS 调色板生成器，可实时预览组件效果并查看对比度矩阵。
 
 ## 工具
 
@@ -136,6 +161,14 @@
 - [Haikei](https://haikei.app) - 直接在浏览器中生成独特的 SVG 背景、色块、波浪等设计素材。
 - [ray.so](https://ray.so) - 由 Raycast 团队出品，将代码片段转换成可直接分享的精美图片。
 - [tldraw](https://www.tldraw.com) - 用于绘制图表、线框图和创意想法的协作式无限白板。
+- [Motion](https://motion.dev) - 面向 Web 的生产级动画库，提供 JavaScript、React 和 Vue 的 API。
+- [Excalidraw](https://excalidraw.com) - 虚拟白板工具，用于绘制手绘风格的图表与线框图。
+- [Squoosh](https://squoosh.app) - 直接在浏览器中压缩和转换图片，支持左右对比查看画质差异。
+- [TinyPNG](https://tinypng.com) - 智能的 AVIF、WebP、PNG 和 JPEG 压缩服务，让网站加载更快。
+- [Typescale](https://typescale.com) - 在真实排版场景中预览模块化字号比例，并导出为 CSS。
+- [LottieFiles](https://lottiefiles.com) - 创建、编辑并发布轻量的 Lottie 动画，并提供海量现成动画素材库。
+- [MagicPattern](https://www.magicpattern.design) - 30+ 款背景、图案、渐变和样机生成器，可导出为图片、SVG 或 CSS。
+- [IconKitchen](https://icon.kitchen) - 为 Android、iOS 和 Web 生成应用图标，并提供真机效果的实时预览。
 - [Rotato](https://rotato.app) - 💵 几分钟内制作 3D 模型图像和视频。
 - [Spline](https://spline.design) - 💵 3D 设计和协作的地方。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
@@ -150,7 +183,10 @@
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
 - [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
+- [Butterick's Practical Typography](https://practicaltypography.com) - 一本排版精美的字体排印读物，写给所有与文字打交道的人。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
+- [Every Layout](https://every-layout.dev) - 💵 通过一组简单、可组合且健壮的布局原语，重新学习 CSS 布局。
+- [Practical UI](https://www.practical-ui.com) - 💵 以逻辑为驱动的方法论，帮助你设计直观、无障碍且美观的界面。
 
 ## 社区
 
@@ -159,4 +195,10 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab 是一个 3D 资产网站，用于发布、分享、发现、购买和销售 3D、VR 和 AR 内容。
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
 - [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
+- [Behance](https://www.behance.net) - Adobe 旗下的创意作品发现与作品集发布平台。
+- [Godly](https://godly.website) - 每日精选的顶尖网页设计灵感库。
+- [Typewolf](https://www.typewolf.com) - 追踪字体潮流：字体清单、案例集，以及真实网站上的排版实践。
+- [Layers](https://layers.to) - 设计师分享 UI 作品的社区，同时提供设计岗位招聘信息。
+- [Minimal Gallery](https://minimal.gallery) - 精选画廊，收录兼具美感与实用性的网站。
+- [Httpster](https://httpster.net) - 网页设计灵感画廊，持续收录新的优秀站点。
 - [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。


### PR DESCRIPTION
## What

Adds 42 new resources across every category, applied consistently to all six language versions (English, 中文, Español, Français, Deutsch, 日本語).

| Category | Added |
| --- | --- |
| UI Libraries | Ark UI, Flowbite, Tremor, Primer, Material Design 3, UIBall Loaders |
| Icons | Font Awesome, Iconbuddy, 3D Icons, Pixelarticons |
| Illustrations | Open Doodles, illlustrations.co, ManyPixels Gallery |
| Templates | Vercel Templates, Astro Themes, Landingfolio |
| Photography | Kaboompics, Gratisography, Rawpixel 💵, Death to Stock 💵 |
| Fonts | Fontsource, Modern Font Stacks, Adobe Fonts 💵 |
| Colors | Radix Colors, UI Colors |
| Tools | Motion, Excalidraw, Squoosh, TinyPNG, Typescale, LottieFiles, MagicPattern, IconKitchen |
| Books | Butterick's Practical Typography, Every Layout 💵, Practical UI 💵 |
| Communities | Behance, Godly, Typewolf, Layers, Minimal Gallery, Httpster |

## How candidates were vetted

Roughly 85 candidate sites were collected and each one was **rendered at 1400px wide and reviewed visually** before any decision — the goal was to keep the list's bar for sites that actually look designed, rather than relying on reputation or a link check alone.

Sites rejected after that visual review include:

- **glazestock.com** — the domain no longer hosts the illustration library; it now serves unrelated spam content.
- **iradesign.io** — host no longer responds (Cloudflare 522).
- **shadows.brumm.af** — host no longer resolves.
- Several others were dropped purely on presentation (too plain, ad-heavy, or dated) or because bot protection made the page impossible to verify.

## Formatting notes

- Every entry follows the existing `- [Name](URL) - Description.` format.
- Free resources are listed before paid ones within each category; paid entries carry the 💵 marker.
- Descriptions are translated per language rather than copied from English.
- No changes outside the six README files.

## Link validation

All 42 URLs were checked. 28 return `200` to a plain HTTP client; the remaining 14 return `403` to `curl` because of Cloudflare/Vercel bot protection — every one of those rendered correctly in a real browser during the visual review, so they are live. No entry was added without a successful page render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcZaLQbMuRit7zNGTHhJNR)_