### PR TITLE
Add 31 curated design resources across all six language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,6 +40,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
 - [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
 - [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
+- [Ark UI](https://ark-ui.com) - Eine Headless-Bibliothek mit über 45 barrierefreien Komponenten für React, Solid, Vue und Svelte.
+- [Tremor](https://tremor.so) - Open-Source-React-Komponenten für Charts und Dashboards, gebaut mit Tailwind CSS und Radix UI.
+- [Kokonut UI](https://kokonutui.com) - Über 100 Open-Source-React-Komponenten mit Tailwind CSS und Motion, mit Live-Vorschau und Copy-Paste-Quellcode.
 
 ## Icons
 
@@ -59,6 +62,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
+- [Lineicons](https://lineicons.com) - Über 27.000 Icons in mehreren Stilen, mit einem kostenlosen Grundset für Web- und App-Oberflächen.
 
 ## Illustrationen
 
@@ -74,6 +78,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
 - [Blush](https://blush.design) - Kostenlose anpassbare Illustrationen mit Figma-Plugin. Erstellen, bearbeiten und verwenden Sie Illustrationen in Ihren Designs.
 - [Open Peeps](https://www.openpeeps.com) - Eine handgezeichnete Illustrationsbibliothek zum Erstellen von Szenen mit Menschen. Sie können sie in Produktillustration, Marketing, Comics und mehr verwenden.
+- [illlustrations](https://illlustrations.co) - Über 120 Open-Source-Illustrationen in AI, SVG, PNG, EPS und Figma, kostenlos für kommerzielle und private Nutzung.
+- [Ouch!](https://icons8.com/illustrations) - Kostenlose Vektor-, 3D- und animierte Illustrationen, die sich vor dem Download umfärben und kombinieren lassen.
 
 ## Vorlagen
 
@@ -81,6 +87,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Moderne und minimalistische Vorlagen für Ihr nächstes Produkt. Erstellt mit React, NextJS, TailwindCSS, Framer Motion und TypeScript.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
 - [Preline](https://preline.co) - 💵 Eine Open-Source Tailwind CSS-Komponentenbibliothek für alle Bedürfnisse. Kommt mit UI-Beispielen & Blöcken, Vorlagen, Plugins, Figma-Designsystem und mehr.
+- [Cruip](https://cruip.com) - 💵 Tailwind-CSS-Vorlagen für Landingpages, Websites und Dashboards, umgesetzt in HTML, React, Next.js und Vue.
 
 ## Fotografie
 
@@ -94,6 +101,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Little Visuals](https://littlevisuals.co) - Kostenlose, hochauflösende Bilder. Verwenden Sie sie, wie Sie wollen - kostenlos für kommerzielle Nutzung.
 - [UI Faces](https://uifaces.co) - Kostenlose KI-generierte Avatare für Ihre kreativen Projekte.
 - [Nappy](https://nappy.co) - Schöne hochauflösende Fotos von Schwarzen und Brown People, kostenlos für private und kommerzielle Nutzung.
+- [Kaboompics](https://kaboompics.com) - Kostenlose Stockfotos und kuratierte Fotoshootings, durchsuchbar nach der Farbpalette jedes Bildes.
 - [Deposit Photos](https://depositphotos.com) - 💵 Lizenzfreie Stock-Fotos, Vektorbilder, Videos und Musik.
 - [Freepik](https://www.freepik.com) - 💵 Millionen kostenloser Vektoren, PSD-Dateien, Fotos und KI-generierter Bilder. Premium-Ressourcen für Ihre kreativen Projekte.
 
@@ -103,6 +111,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Inter](https://rsms.me/inter/) - Eine variable Schriftfamilie für Text-Benutzeroberflächen.
 - [Fontshare](https://www.fontshare.com) - Ein kostenloser Font-Dienst der Indian Type Foundry mit hochwertigen Schriften für private und kommerzielle Nutzung.
 - [Uncut](https://uncut.wtf) - Eine kuratierte Bibliothek zeitgenössischer Open-Source-Schriften, kostenlos zum Herunterladen und Verwenden.
+- [Open Foundry](https://open-foundry.com) - Eine kuratierte Auswahl quelloffener Schriften, präsentiert mit der Sorgfalt eines gedruckten Schriftmusters.
+- [Fontsource](https://fontsource.org) - Über 2000 quelloffene Schriftfamilien als npm-Module, um Schriften selbst zu hosten statt ein CDN einzubinden.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - Die erste quelloffene Schriftgießerei mit sorgfältig gestalteten Schriften, frei für jedes Projekt.
+- [Geist](https://vercel.com/font) - Vercels quelloffene Sans-, Mono- und Pixel-Schriften, gestaltet für Entwickleroberflächen.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Kaufen Sie kuratierte Qualitätsprodukte und Waren.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
@@ -124,6 +136,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
 - [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
 - [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
+- [Radix Colors](https://www.radix-ui.com/colors) - Ein zwölfstufiges Farbsystem für Benutzeroberflächen mit passenden hellen, dunklen und Alpha-Skalen.
+- [UI Colors](https://uicolors.app) - Erzeuge Tailwind-CSS-Farbskalen aus jeder Markenfarbe und sieh sie direkt an echten Komponenten.
+- [Khroma](https://www.khroma.co) - Trainiert ein Modell auf deine Lieblingsfarben und erzeugt daraus endlose Paletten zum Suchen und Speichern.
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - Prüfe jede Vorder- und Hintergrundfarbe live gegen die WCAG-Kontraststufen, während du sie anpasst.
 
 ## Werkzeuge
 
@@ -135,6 +151,12 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Haikei](https://haikei.app) - Erzeuge einzigartige SVG-Hintergründe, Blobs, Wellen und weitere Design-Assets direkt im Browser.
 - [ray.so](https://ray.so) - Verwandelt Code-Snippets in schöne, teilbare Bilder – von den Machern von Raycast.
 - [tldraw](https://www.tldraw.com) - Ein kollaboratives, unendliches Whiteboard zum Skizzieren von Diagrammen, Wireframes und Ideen.
+- [Motion](https://motion.dev) - Eine produktionsreife, quelloffene Animationsbibliothek für React, JavaScript und Vue.
+- [Excalidraw](https://excalidraw.com) - Ein virtuelles Whiteboard für Diagramme, Wireframes und Skizzen im Handzeichnungsstil.
+- [Squoosh](https://squoosh.app) - Bilder direkt im Browser komprimieren und vergleichen, mit Live-Vorschau jedes Codecs nebeneinander.
+- [Animista](https://animista.net) - Fertige CSS-Animationen durchstöbern, anpassen und nur den benötigten Code herauskopieren.
+- [Utopia](https://utopia.fyi) - Rechner für fluide Schrift- und Abstandsskalen, die zwischen Viewports interpolieren statt an Breakpoints zu springen.
+- [MagicPattern](https://www.magicpattern.design) - Über 30 Generatoren für Hintergründe, Muster, Verläufe und Blobs, exportierbar als Bild, SVG oder CSS.
 - [Rotato](https://rotato.app) - 💵 3D-Mockup-Bilder und Filme in Minuten.
 - [Spline](https://spline.design) - 💵 Ein Ort zum Entwerfen und Zusammenarbeiten in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
@@ -144,12 +166,17 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Canva](https://www.canva.com) - 💵 Erstellen Sie mühelos atemberaubende Designs mit Canvas Drag & Drop-Funktion und professionellen Layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digitale Produktdesign-Plattform für die weltbesten Benutzererfahrungen.
 - [Screen Studio](https://screen.studio) - 💵 macOS-Bildschirmrekorder mit automatischem Zoom und weichen Animationen für polierte Produkt-Demos.
+- [Jitter](https://jitter.video) - 💵 Ein Motion-Design-Werkzeug für Produktteams, mit vertrauter Arbeitsfläche und Video- oder Lottie-Export.
 
 ## Bücher
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
 - [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
+- [Inclusive Components](https://inclusive-components.design) - Eine Musterbibliothek, die Stück für Stück zeigt, wie sich gängige Interface-Komponenten barrierefrei bauen lassen.
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimeros Buch über Handwerk und Absicht hinter Designarbeit, kostenlos online lesbar.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
+- [Every Layout](https://every-layout.dev) - 💵 CSS-Layout neu lernen anhand einfacher, kombinierbarer Layout-Primitive.
+- [Animations on the Web](https://animations.dev) - 💵 Ein interaktiver Kurs von Emil Kowalski über Theorie und Praxis von Animationen, die sich richtig anfühlen.
 
 ## Communities
 
@@ -158,4 +185,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Sketchfab](https://sketchfab.com) - Sketchfab ist eine 3D-Asset-Website zum Veröffentlichen, Teilen, Entdecken, Kaufen und Verkaufen von 3D-, VR- und AR-Inhalten.
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
 - [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
+- [Typewolf](https://www.typewolf.com) - Was in der Typografie gerade angesagt ist: Schriftlisten, Lookbooks und Inspiration von echten Websites.
+- [The Component Gallery](https://component.gallery) - Ein Verzeichnis von Interface-Komponenten mit echten Beispielen aus öffentlichen Designsystemen.
+- [Minimal Gallery](https://minimal.gallery) - Eine kuratierte Galerie schöner und funktionaler Websites, mit wöchentlichem Digest.
+- [One Page Love](https://onepagelove.com) - Über 9000 handverlesene One-Page-Websites und Abschnittsbeispiele, kuratiert seit 2008.
 - [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
 - [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
+- [Ark UI](https://ark-ui.com) - Una librería headless con más de 45 componentes accesibles que funciona en React, Solid, Vue y Svelte.
+- [Tremor](https://tremor.so) - Componentes React de código abierto para crear gráficos y paneles, construidos con Tailwind CSS y Radix UI.
+- [Kokonut UI](https://kokonutui.com) - Más de 100 componentes React de código abierto con Tailwind CSS y Motion, con vistas previas en vivo y código para copiar y pegar.
 
 ## Iconos
 
@@ -59,6 +62,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
+- [Lineicons](https://lineicons.com) - Más de 27 000 iconos en varios estilos, con un conjunto básico gratuito para interfaces web y de apps.
 
 ## Ilustraciones
 
@@ -74,6 +78,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
 - [Blush](https://blush.design) - Ilustraciones personalizables gratuitas con Plugin de Figma. Crea, edita y usa ilustraciones en tus diseños.
 - [Open Peeps](https://www.openpeeps.com) - Una librería de ilustraciones dibujadas a mano para crear escenas de personas. Puedes usarlas en ilustración de productos, marketing, cómics y más.
+- [illlustrations](https://illlustrations.co) - Más de 120 ilustraciones de código abierto en AI, SVG, PNG, EPS y Figma, gratis para uso comercial y personal.
+- [Ouch!](https://icons8.com/illustrations) - Ilustraciones vectoriales, 3D y animadas gratuitas que puedes recolorear y combinar antes de descargar.
 
 ## Plantillas
 
@@ -81,6 +87,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Plantillas modernas y minimalistas para construir tu próximo producto. Construidas con React, NextJS, TailwindCSS, Framer Motion y Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
 - [Preline](https://preline.co) - 💵 Una librería de componentes Tailwind CSS de código abierto para cualquier necesidad. Viene con ejemplos y bloques UI, plantillas, plugins, sistema de diseño Figma y más.
+- [Cruip](https://cruip.com) - 💵 Plantillas de landing pages, sitios y paneles con Tailwind CSS, codificadas en HTML, React, Next.js y Vue.
 
 ## Fotografía
 
@@ -94,6 +101,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Little Visuals](https://littlevisuals.co) - Imágenes gratuitas de alta resolución. Úsalas como quieras - gratis para uso comercial.
 - [UI Faces](https://uifaces.co) - Avatares gratuitos generados por IA para tus proyectos creativos.
 - [Nappy](https://nappy.co) - Hermosas fotos en alta resolución de personas negras y morenas, gratis para uso personal y comercial.
+- [Kaboompics](https://kaboompics.com) - Fotos de stock gratuitas y sesiones seleccionadas, con búsqueda por la paleta de color de cada imagen.
 - [Deposit Photos](https://depositphotos.com) - 💵 Fotos de stock libres de derechos, imágenes vectoriales, videos y música.
 - [Freepik](https://www.freepik.com) - 💵 Millones de vectores gratuitos, archivos PSD, fotos e imágenes generadas por IA. Recursos premium para tus proyectos creativos.
 
@@ -103,6 +111,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Inter](https://rsms.me/inter/) - Una familia de fuentes variable para interfaces de texto.
 - [Fontshare](https://www.fontshare.com) - Un servicio de fuentes gratuito de Indian Type Foundry, con tipografías de calidad licenciadas para uso personal y comercial.
 - [Uncut](https://uncut.wtf) - Una biblioteca curada de tipografías contemporáneas de código abierto, gratis para descargar y usar.
+- [Open Foundry](https://open-foundry.com) - Una muestra curada de tipografías de código abierto, presentada con el cuidado de un espécimen impreso.
+- [Fontsource](https://fontsource.org) - Más de 2000 familias tipográficas de código abierto empaquetadas como módulos npm, para alojar las fuentes tú mismo en lugar de usar un CDN.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - La primera fundición tipográfica de código abierto, con tipografías bien construidas y libres para cualquier proyecto.
+- [Geist](https://vercel.com/font) - Las tipografías sans, mono y pixel de código abierto de Vercel, diseñadas para interfaces orientadas a desarrolladores.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Compra productos y bienes de calidad y curados.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
@@ -124,6 +136,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
 - [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
 - [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un sistema de color de 12 pasos para interfaces, con escalas claras, oscuras y alfa equivalentes.
+- [UI Colors](https://uicolors.app) - Genera escalas de color de Tailwind CSS a partir de cualquier color de marca y previsualízalas en componentes reales.
+- [Khroma](https://www.khroma.co) - Entrena un modelo con los colores que te gustan y genera paletas infinitas que puedes buscar y guardar.
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - Comprueba cualquier par de color de texto y fondo frente a los niveles de contraste WCAG mientras lo ajustas.
 
 ## Herramientas
 
@@ -135,6 +151,12 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Haikei](https://haikei.app) - Genera fondos SVG únicos, blobs, ondas y otros recursos de diseño directamente en el navegador.
 - [ray.so](https://ray.so) - Convierte fragmentos de código en imágenes bonitas listas para compartir, de los creadores de Raycast.
 - [tldraw](https://www.tldraw.com) - Una pizarra infinita colaborativa para bocetar diagramas, wireframes e ideas.
+- [Motion](https://motion.dev) - Una librería de animación de código abierto y de nivel producción para React, JavaScript y Vue.
+- [Excalidraw](https://excalidraw.com) - Una pizarra virtual para diagramas, wireframes y bocetos con estilo dibujado a mano.
+- [Squoosh](https://squoosh.app) - Comprime y compara imágenes directamente en el navegador, con una vista previa lado a lado de cada códec.
+- [Animista](https://animista.net) - Explora animaciones CSS listas para usar, ajústalas y copia solo el código que necesitas.
+- [Utopia](https://utopia.fyi) - Calculadoras de escalas fluidas de tipografía y espaciado que interpolan entre viewports en lugar de saltar en los breakpoints.
+- [MagicPattern](https://www.magicpattern.design) - Más de 30 generadores de fondos, patrones, degradados y blobs, exportables como imagen, SVG o CSS.
 - [Rotato](https://rotato.app) - 💵 Imágenes mockup 3D y películas en minutos.
 - [Spline](https://spline.design) - 💵 Un lugar para diseñar y colaborar en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
@@ -144,12 +166,17 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Canva](https://www.canva.com) - 💵 Crea diseños impresionantes fácilmente con la función de arrastrar y soltar de Canva y diseños profesionales.
 - [InVision](https://www.invisionapp.com) - 💵 Plataforma de diseño de productos digitales que impulsa las mejores experiencias de usuario del mundo.
 - [Screen Studio](https://screen.studio) - 💵 Grabador de pantalla para macOS con zoom automático y animaciones suaves para demos de producto pulidas.
+- [Jitter](https://jitter.video) - 💵 Una herramienta de motion design para equipos de producto, con un lienzo familiar y exportación a vídeo o Lottie.
 
 ## Libros
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
+- [Inclusive Components](https://inclusive-components.design) - Una biblioteca de patrones que explica, pieza a pieza, cómo construir componentes de interfaz accesibles.
+- [The Shape of Design](https://shapeofdesignbook.com) - El libro de Frank Chimero sobre el oficio y la intención detrás del diseño, gratis para leer en línea.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
+- [Every Layout](https://every-layout.dev) - 💵 Reaprende el layout en CSS a través de un conjunto de primitivas simples y componibles.
+- [Animations on the Web](https://animations.dev) - 💵 Un curso interactivo de Emil Kowalski sobre la teoría y la práctica detrás de animaciones que se sienten bien.
 
 ## Comunidades
 
@@ -158,4 +185,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Sketchfab](https://sketchfab.com) - Sketchfab es un sitio web de recursos 3D usado para publicar, compartir, descubrir, comprar y vender contenido 3D, VR y AR.
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
 - [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
+- [Typewolf](https://www.typewolf.com) - Lo que se lleva en tipografía: listas de fuentes, lookbooks e inspiración tomada de sitios reales.
+- [The Component Gallery](https://component.gallery) - Un repositorio de componentes de interfaz con ejemplos reales tomados de sistemas de diseño públicos.
+- [Minimal Gallery](https://minimal.gallery) - Una galería seleccionada de sitios web bellos y funcionales, con un resumen semanal.
+- [One Page Love](https://onepagelove.com) - Más de 9000 sitios de una sola página y ejemplos de secciones seleccionados a mano desde 2008.
 - [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,6 +40,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
 - [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
+- [Ark UI](https://ark-ui.com) - Une bibliothèque headless de plus de 45 composants accessibles, compatible React, Solid, Vue et Svelte.
+- [Tremor](https://tremor.so) - Composants React open source pour créer graphiques et tableaux de bord, basés sur Tailwind CSS et Radix UI.
+- [Kokonut UI](https://kokonutui.com) - Plus de 100 composants React open source avec Tailwind CSS et Motion, avec aperçus en direct et code à copier-coller.
 
 ## Icônes
 
@@ -59,6 +62,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
+- [Lineicons](https://lineicons.com) - Plus de 27 000 icônes en plusieurs styles, avec un jeu de base gratuit pour les interfaces web et applicatives.
 
 ## Illustrations
 
@@ -74,6 +78,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
 - [Blush](https://blush.design) - Illustrations personnalisables gratuites avec Plugin Figma. Créez, éditez et utilisez des illustrations dans vos designs.
 - [Open Peeps](https://www.openpeeps.com) - Une bibliothèque d'illustrations dessinées à la main pour créer des scènes de personnes. Vous pouvez les utiliser dans l'illustration de produit, marketing, bandes dessinées et plus.
+- [illlustrations](https://illlustrations.co) - Plus de 120 illustrations open source en AI, SVG, PNG, EPS et Figma, libres pour un usage commercial et personnel.
+- [Ouch!](https://icons8.com/illustrations) - Illustrations vectorielles, 3D et animées gratuites, à recolorer et combiner avant téléchargement.
 
 ## Modèles
 
@@ -81,6 +87,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modèles modernes et minimalistes pour construire votre prochain produit. Construits avec React, NextJS, TailwindCSS, Framer Motion et Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
 - [Preline](https://preline.co) - 💵 Une bibliothèque de composants Tailwind CSS open source pour tous les besoins. Livré avec des exemples et blocs UI, modèles, plugins, système de design Figma et plus.
+- [Cruip](https://cruip.com) - 💵 Modèles de landing pages, sites et tableaux de bord en Tailwind CSS, codés en HTML, React, Next.js et Vue.
 
 ## Photographie
 
@@ -94,6 +101,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Little Visuals](https://littlevisuals.co) - Images gratuites, haute résolution. Utilisez-les comme vous voulez - gratuit pour usage commercial.
 - [UI Faces](https://uifaces.co) - Avatars gratuits générés par IA pour vos projets créatifs.
 - [Nappy](https://nappy.co) - De belles photos haute résolution de personnes noires et métisses, gratuites pour un usage personnel et commercial.
+- [Kaboompics](https://kaboompics.com) - Photos libres de droits et séries sélectionnées, avec une recherche par palette de couleurs de chaque image.
 - [Deposit Photos](https://depositphotos.com) - 💵 Photos stock libres de droits, images vectorielles, vidéos et musique.
 - [Freepik](https://www.freepik.com) - 💵 Millions de vecteurs gratuits, fichiers PSD, photos et images générées par IA. Ressources premium pour vos projets créatifs.
 
@@ -103,6 +111,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Inter](https://rsms.me/inter/) - Une famille de polices variable pour interfaces texte.
 - [Fontshare](https://www.fontshare.com) - Un service de polices gratuit de l'Indian Type Foundry, avec des typographies de qualité sous licence personnelle et commerciale.
 - [Uncut](https://uncut.wtf) - Une bibliothèque sélectionnée de typographies contemporaines open source, libres de téléchargement et d'utilisation.
+- [Open Foundry](https://open-foundry.com) - Une sélection de fontes open source, présentée avec le soin d'un spécimen typographique imprimé.
+- [Fontsource](https://fontsource.org) - Plus de 2000 familles de polices open source packagées en modules npm, pour héberger vos fontes plutôt que de passer par un CDN.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - La première fonderie typographique open source, avec des fontes soignées, libres pour tout projet.
+- [Geist](https://vercel.com/font) - Les fontes open source sans, mono et pixel de Vercel, conçues pour les interfaces destinées aux développeurs.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Achetez des produits et biens de qualité, sélectionnés.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
@@ -124,6 +136,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
 - [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
 - [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un système de couleurs en 12 paliers pour les interfaces, avec des échelles claires, sombres et alpha correspondantes.
+- [UI Colors](https://uicolors.app) - Générez des échelles de couleurs Tailwind CSS à partir de n'importe quelle couleur de marque et prévisualisez-les sur de vrais composants.
+- [Khroma](https://www.khroma.co) - Entraîne un modèle sur les couleurs que vous aimez, puis génère des palettes infinies à rechercher et enregistrer.
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - Vérifiez n'importe quel couple texte/fond selon les niveaux de contraste WCAG, en temps réel.
 
 ## Outils
 
@@ -135,6 +151,12 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Haikei](https://haikei.app) - Générez des arrière-plans SVG uniques, blobs, vagues et autres ressources de design directement dans le navigateur.
 - [ray.so](https://ray.so) - Transformez des extraits de code en belles images prêtes à partager, par les créateurs de Raycast.
 - [tldraw](https://www.tldraw.com) - Un tableau blanc infini et collaboratif pour esquisser diagrammes, wireframes et idées.
+- [Motion](https://motion.dev) - Une bibliothèque d'animation open source de qualité production pour React, JavaScript et Vue.
+- [Excalidraw](https://excalidraw.com) - Un tableau blanc virtuel pour des diagrammes, wireframes et croquis au style dessiné à la main.
+- [Squoosh](https://squoosh.app) - Compressez et comparez des images directement dans le navigateur, avec un aperçu côte à côte de chaque codec.
+- [Animista](https://animista.net) - Parcourez des animations CSS prêtes à l'emploi, ajustez-les et ne copiez que le code dont vous avez besoin.
+- [Utopia](https://utopia.fyi) - Des calculateurs d'échelles fluides de typographie et d'espacement qui interpolent entre les viewports au lieu de sauter aux points de rupture.
+- [MagicPattern](https://www.magicpattern.design) - Plus de 30 générateurs de fonds, motifs, dégradés et blobs, exportables en image, SVG ou CSS.
 - [Rotato](https://rotato.app) - 💵 Images de maquette 3D et films en minutes.
 - [Spline](https://spline.design) - 💵 Un lieu pour concevoir et collaborer en 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
@@ -144,12 +166,17 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Canva](https://www.canva.com) - 💵 Créez facilement des designs époustouflants avec la fonction glisser-déposer de Canva et des mises en page professionnelles.
 - [InVision](https://www.invisionapp.com) - 💵 Plateforme de design de produit numérique alimentant les meilleures expériences utilisateur du monde.
 - [Screen Studio](https://screen.studio) - 💵 Enregistreur d'écran macOS avec zoom automatique et animations fluides pour des démos produit soignées.
+- [Jitter](https://jitter.video) - 💵 Un outil de motion design pour les équipes produit, avec un canevas familier et un export vidéo ou Lottie.
 
 ## Livres
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
+- [Inclusive Components](https://inclusive-components.design) - Une bibliothèque de patterns qui explique, pièce par pièce, comment construire des composants d'interface accessibles.
+- [The Shape of Design](https://shapeofdesignbook.com) - Le livre de Frank Chimero sur l'artisanat et l'intention derrière le design, à lire gratuitement en ligne.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
+- [Every Layout](https://every-layout.dev) - 💵 Réapprenez la mise en page CSS à travers un ensemble de primitives simples et composables.
+- [Animations on the Web](https://animations.dev) - 💵 Un cours interactif d'Emil Kowalski sur la théorie et la pratique des animations qui sonnent juste.
 
 ## Communautés
 
@@ -158,4 +185,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Sketchfab](https://sketchfab.com) - Sketchfab est un site web d'actifs 3D utilisé pour publier, partager, découvrir, acheter et vendre du contenu 3D, VR et AR.
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
 - [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
+- [Typewolf](https://www.typewolf.com) - Les tendances typographiques : listes de fontes, lookbooks et inspiration issue de vrais sites.
+- [The Component Gallery](https://component.gallery) - Un répertoire de composants d'interface avec des exemples réels issus de design systems publics.
+- [Minimal Gallery](https://minimal.gallery) - Une galerie sélectionnée de sites beaux et fonctionnels, avec un condensé hebdomadaire.
+- [One Page Love](https://onepagelove.com) - Plus de 9000 sites one page et exemples de sections sélectionnés à la main depuis 2008.
 - [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,9 @@
 - [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
 - [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
 - [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
+- [Ark UI](https://ark-ui.com) - React、Solid、Vue、Svelte に対応した 45 以上のアクセシブルなヘッドレスコンポーネントライブラリ。
+- [Tremor](https://tremor.so) - Tailwind CSS と Radix UI で構築された、チャートやダッシュボードを作るためのオープンソース React コンポーネント。
+- [Kokonut UI](https://kokonutui.com) - Tailwind CSS と Motion で構築された 100 以上のオープンソース React コンポーネント。ライブプレビューとコピペ可能なソース付き。
 
 ## アイコン
 
@@ -59,6 +62,7 @@
 - [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
+- [Lineicons](https://lineicons.com) - 複数スタイルで 27,000 以上のアイコン。Web やアプリの UI 向けに無料のコアセットを提供。
 
 ## イラスト
 
@@ -74,6 +78,8 @@
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
 - [Blush](https://blush.design) - Figma プラグイン付きの無料カスタマイズ可能イラスト。デザインでイラストを作成、編集、使用できます。
 - [Open Peeps](https://www.openpeeps.com) - 人々のシーンを作成するための手描きイラストライブラリ。製品イラスト、マーケティング、コミックなどで使用できます。
+- [illlustrations](https://illlustrations.co) - AI、SVG、PNG、EPS、Figma 形式で提供される 120 以上のオープンソースイラスト。商用・個人利用ともに無料。
+- [Ouch!](https://icons8.com/illustrations) - ダウンロード前に色替えや組み合わせができる、無料のベクター・3D・アニメーションイラスト。
 
 ## テンプレート
 
@@ -81,6 +87,7 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 次の製品を構築するためのモダンでミニマリストなテンプレート。React、NextJS、TailwindCSS、Framer Motion、TypeScript で構築。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
 - [Preline](https://preline.co) - 💵 あらゆるニーズに対応するオープンソース Tailwind CSS コンポーネントライブラリ。UI サンプル＆ブロック、テンプレート、プラグイン、Figma デザインシステムなどが付属。
+- [Cruip](https://cruip.com) - 💵 HTML、React、Next.js、Vue で実装された Tailwind CSS のランディングページ・サイト・ダッシュボードテンプレート。
 
 ## 写真
 
@@ -94,6 +101,7 @@
 - [Little Visuals](https://littlevisuals.co) - 無料、高解像度画像。お好みに応じて使用 - 商用利用無料。
 - [UI Faces](https://uifaces.co) - クリエイティブプロジェクト用の無料 AI 生成アバター。
 - [Nappy](https://nappy.co) - 黒人・褐色の肌の人々を撮影した高解像度の写真。個人利用・商用利用ともに無料。
+- [Kaboompics](https://kaboompics.com) - 無料のストックフォトと厳選されたフォトシュート。画像ごとのカラーパレットで検索できる。
 - [Deposit Photos](https://depositphotos.com) - 💵 ロイヤリティフリーストック写真、ベクター画像、動画、音楽。
 - [Freepik](https://www.freepik.com) - 💵 数百万の無料ベクター、PSD ファイル、写真、AI 生成画像。クリエイティブプロジェクト用のプレミアムリソース。
 
@@ -103,6 +111,10 @@
 - [Inter](https://rsms.me/inter/) - テキストインターフェース用の可変フォントファミリー。
 - [Fontshare](https://www.fontshare.com) - Indian Type Foundry による無料フォントサービス。個人利用・商用利用が可能な高品質書体を提供。
 - [Uncut](https://uncut.wtf) - 現代的なオープンソース書体を厳選したライブラリ。無料でダウンロードして利用可能。
+- [Open Foundry](https://open-foundry.com) - オープンソース書体を厳選して紹介するサイト。印刷見本帳のような丁寧な見せ方が魅力。
+- [Fontsource](https://fontsource.org) - npm モジュールとして配布される 2,000 以上のオープンソース書体ファミリー。CDN に頼らず自前でホストできる。
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - 世界初のオープンソース活字工房。丁寧に作られた書体をどんなプロジェクトでも自由に使える。
+- [Geist](https://vercel.com/font) - Vercel によるオープンソースのサンセリフ・等幅・ピクセル書体。開発者向け UI のために設計されている。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 厳選された品質の商品と製品をショッピング。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
@@ -124,6 +136,10 @@
 - [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
 - [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
+- [Radix Colors](https://www.radix-ui.com/colors) - UI 向けの 12 段階カラーシステム。ライト・ダーク・アルファの各スケールが対応して用意されている。
+- [UI Colors](https://uicolors.app) - 任意のブランドカラーから Tailwind CSS のカラースケールを生成し、実際のコンポーネント上でプレビューできる。
+- [Khroma](https://www.khroma.co) - 好みの色を学習させ、検索・保存できるパレットを無限に生成してくれるツール。
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - 前景色と背景色の組み合わせを調整しながら、WCAG のコントラスト基準を満たすか確認できる。
 
 ## ツール
 
@@ -135,6 +151,12 @@
 - [Haikei](https://haikei.app) - ブラウザ上でユニークな SVG の背景、ブロブ、波などのデザインアセットを生成。
 - [ray.so](https://ray.so) - コードスニペットを共有しやすい美しい画像に変換。Raycast チームによるツール。
 - [tldraw](https://www.tldraw.com) - 図やワイヤーフレーム、アイデアをスケッチできる、共同編集対応の無限ホワイトボード。
+- [Motion](https://motion.dev) - React、JavaScript、Vue 向けのプロダクション品質なオープンソースアニメーションライブラリ。
+- [Excalidraw](https://excalidraw.com) - 手描き風の図やワイヤーフレーム、スケッチを描けるバーチャルホワイトボード。
+- [Squoosh](https://squoosh.app) - ブラウザー上で画像を圧縮・比較できるツール。各コーデックの結果を並べてライブプレビューできる。
+- [Animista](https://animista.net) - 既製の CSS アニメーションを探して調整し、必要な分だけコードをコピーできる。
+- [Utopia](https://utopia.fyi) - ブレークポイントで飛ばずにビューポート間を補間する、フルイドなタイプ・スペーススケールの計算ツール。
+- [MagicPattern](https://www.magicpattern.design) - 背景・パターン・グラデーション・ブロブを作れる 30 以上のジェネレーター。画像・SVG・CSS で書き出せる。
 - [Rotato](https://rotato.app) - 💵 数分で 3D モックアップ画像と動画。
 - [Spline](https://spline.design) - 💵 3D でデザインし協力する場所。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
@@ -144,12 +166,17 @@
 - [Canva](https://www.canva.com) - 💵 Canva のドラッグ＆ドロップ機能とプロフェッショナルレイアウトで素晴らしいデザインを簡単に作成。
 - [InVision](https://www.invisionapp.com) - 💵 世界最高のユーザー体験を推進するデジタル製品デザインプラットフォーム。
 - [Screen Studio](https://screen.studio) - 💵 自動ズームと滑らかなアニメーションを備えた macOS 向け画面録画ツール。洗練された製品デモに最適。
+- [Jitter](https://jitter.video) - 💵 プロダクトチーム向けのモーションデザインツール。使い慣れたキャンバスで作り、動画や Lottie で書き出せる。
 
 ## 書籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
 - [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
+- [Inclusive Components](https://inclusive-components.design) - よくある UI コンポーネントをアクセシブルに作る方法を一つずつ解説するパターンライブラリ。
+- [The Shape of Design](https://shapeofdesignbook.com) - デザインの手仕事と意図について書かれた Frank Chimero の著作。オンラインで無料で読める。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
+- [Every Layout](https://every-layout.dev) - 💵 シンプルで組み合わせ可能なレイアウトプリミティブを通して、CSS レイアウトを学び直す一冊。
+- [Animations on the Web](https://animations.dev) - 💵 心地よいアニメーションの理論と実践を学べる、Emil Kowalski によるインタラクティブな講座。
 
 ## コミュニティ
 
@@ -158,4 +185,8 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab は 3D、VR、AR コンテンツを公開、共有、発見、売買するために使用される 3D アセットウェブサイト。
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
 - [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
+- [Typewolf](https://www.typewolf.com) - 実在するサイトから集めたフォントリストやルックブックで、いまのタイポグラフィの潮流を追える。
+- [The Component Gallery](https://component.gallery) - 公開されているデザインシステムから集めた実例つきの UI コンポーネント集。
+- [Minimal Gallery](https://minimal.gallery) - 美しく機能的なウェブサイトを厳選したギャラリー。毎週のダイジェストも配信している。
+- [One Page Love](https://onepagelove.com) - 2008 年から厳選され続けている、9,000 以上のワンページサイトとセクション事例。
 - [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
 - [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
 - [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
+- [Ark UI](https://ark-ui.com) - A headless library of 45+ accessible components that works across React, Solid, Vue and Svelte.
+- [Tremor](https://tremor.so) - Open-source React components for building charts and dashboards, built with Tailwind CSS and Radix UI.
+- [Kokonut UI](https://kokonutui.com) - 100+ open-source React components built with Tailwind CSS and Motion, with live previews and copy-paste source.
 
 ## Icons
 
@@ -59,6 +62,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
+- [Lineicons](https://lineicons.com) - 27,000+ icons across multiple styles, with a free core set for web and app interfaces.
 
 ## Illustrations
 
@@ -74,6 +78,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
 - [Blush](https://blush.design) - Free customizable illustrations with Figma Plugin. Create, edit, and use illustrations in your designs.
 - [Open Peeps](https://www.openpeeps.com) - A hand-drawn illustration library to create scenes of people. You can use them in product illustration, marketing, comics, and more.
+- [illlustrations](https://illlustrations.co) - 120+ open-source illustrations in AI, SVG, PNG, EPS and Figma, free for commercial and personal use.
+- [Ouch!](https://icons8.com/illustrations) - Free vector, 3D and animated illustrations you can recolor and mix before downloading.
 
 ## Templates
 
@@ -81,6 +87,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modern and minimalist templates for building your next product. Built with React, NextJS, TailwindCSS, Framer Motion and Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
 - [Preline](https://preline.co) - 💵 An open-source Tailwind CSS components library for any needs. Comes with UI examples & blocks, templates, plugins, Figma design system and more.
+- [Cruip](https://cruip.com) - 💵 Tailwind CSS landing page, website and dashboard templates coded in HTML, React, Next.js and Vue.
 
 ## Photography
 
@@ -94,6 +101,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Little Visuals](https://littlevisuals.co) - Free, high resolution images. Use them anyway you want - free for commercial use.
 - [UI Faces](https://uifaces.co) - Free AI-generated avatars for your creative projects.
 - [Nappy](https://nappy.co) - Beautiful high-resolution photos of Black and Brown people, free for personal and commercial use.
+- [Kaboompics](https://kaboompics.com) - Free stock photos and curated photoshoots, searchable by the color palette of each image.
 - [Deposit Photos](https://depositphotos.com) - 💵 Royalty-free Stock Photos, Vector Images, Videos and Music.
 - [Freepik](https://www.freepik.com) - 💵 Millions of free vectors, PSD files, photos and AI-generated images. Premium resources for your creative projects.
 
@@ -103,6 +111,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Inter](https://rsms.me/inter/) - A variable font family for text interfaces.
 - [Fontshare](https://www.fontshare.com) - A free font service from the Indian Type Foundry, with quality typefaces licensed for personal and commercial use.
 - [Uncut](https://uncut.wtf) - A curated library of contemporary open-source typefaces, free to download and use.
+- [Open Foundry](https://open-foundry.com) - A curated showcase of open-source typefaces, presented with the care of a printed type specimen.
+- [Fontsource](https://fontsource.org) - 2,000+ open-source font families packaged as npm modules, so you can self-host type instead of linking a CDN.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - The first open-source type foundry, with well-crafted typefaces free to use in any project.
+- [Geist](https://vercel.com/font) - Vercel's open-source sans, mono and pixel typefaces, designed for developer-facing interfaces.
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 Shop quality, curated goods and products.
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 Shop quality, curated fonts from indie font foundries.
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
@@ -124,6 +136,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
 - [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
 - [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
+- [Radix Colors](https://www.radix-ui.com/colors) - A 12-step color system for user interfaces, with matching light, dark and alpha scales.
+- [UI Colors](https://uicolors.app) - Generate Tailwind CSS color scales from any brand color and preview them on real components.
+- [Khroma](https://www.khroma.co) - Trains a model on the colors you like, then generates endless palettes you can search and save.
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - Check any foreground and background pair against the WCAG contrast levels while you tweak it.
 
 ## Tools
 
@@ -135,6 +151,12 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Haikei](https://haikei.app) - Generate unique SVG backgrounds, blobs, waves and other design assets right in the browser.
 - [ray.so](https://ray.so) - Turn code snippets into beautiful images ready to share, by the makers of Raycast.
 - [tldraw](https://www.tldraw.com) - A collaborative infinite whiteboard for sketching diagrams, wireframes and ideas.
+- [Motion](https://motion.dev) - A production-grade, open-source animation library for React, JavaScript and Vue.
+- [Excalidraw](https://excalidraw.com) - A virtual whiteboard for hand-drawn style diagrams, wireframes and sketches.
+- [Squoosh](https://squoosh.app) - Compress and compare images right in the browser, with a live side-by-side preview of every codec.
+- [Animista](https://animista.net) - Browse ready-made CSS animations, tweak them and copy out only the code you need.
+- [Utopia](https://utopia.fyi) - Calculators for fluid type and space scales that interpolate between viewports instead of snapping at breakpoints.
+- [MagicPattern](https://www.magicpattern.design) - 30+ generators for backgrounds, patterns, gradients and blobs, exportable as images, SVG or CSS.
 - [Rotato](https://rotato.app) - 💵 3D mockup images and movies in minutes.
 - [Spline](https://spline.design) - 💵 A place to design and collaborate in 3D.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
@@ -144,12 +166,17 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Canva](https://www.canva.com) - 💵 Create stunning designs easily with Canva's drag-and-drop feature and professional layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digital product design platform powering the world's best user experiences.
 - [Screen Studio](https://screen.studio) - 💵 macOS screen recorder with automatic zoom and smooth animations for polished product demos.
+- [Jitter](https://jitter.video) - 💵 A motion design tool for product teams, with a familiar canvas and video or Lottie export.
 
 ## Books
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
+- [Inclusive Components](https://inclusive-components.design) - A pattern library that walks through building common interface components accessibly, piece by piece.
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimero's book on the craft and intent behind design work, free to read online.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
+- [Every Layout](https://every-layout.dev) - 💵 Relearn CSS layout through a set of simple, composable layout primitives.
+- [Animations on the Web](https://animations.dev) - 💵 An interactive course by Emil Kowalski on the theory and practice behind animations that feel right.
 
 ## Communities
 
@@ -158,4 +185,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Sketchfab](https://sketchfab.com) - Sketchfab is a 3D asset website used to publish, share, discover, buy and sell 3D, VR and AR content.
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
 - [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
+- [Typewolf](https://www.typewolf.com) - What's trending in type: font lists, lookbooks and typography inspiration from real websites.
+- [The Component Gallery](https://component.gallery) - A repository of interface components with real examples drawn from public design systems.
+- [Minimal Gallery](https://minimal.gallery) - A curated gallery of beautiful and functional websites, with a weekly digest.
+- [One Page Love](https://onepagelove.com) - 9,000+ hand-picked one page websites and section examples, curated since 2008.
 - [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,9 @@
 - [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
 - [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
 - [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
+- [Ark UI](https://ark-ui.com) - 无样式的可访问组件库，提供 45+ 组件，支持 React、Solid、Vue 和 Svelte。
+- [Tremor](https://tremor.so) - 用于构建图表和仪表板的开源 React 组件，基于 Tailwind CSS 和 Radix UI 构建。
+- [Kokonut UI](https://kokonutui.com) - 100+ 开源 React 组件，基于 Tailwind CSS 和 Motion 构建，提供实时预览和可复制粘贴的源码。
 
 ## 图标
 
@@ -60,6 +63,7 @@
 
 - [React Icons](https://react-icons.github.io/react-icons/) - 使用 react-icons 轻松在 React 项目中包含流行图标。
 - [Iconoir](https://iconoir.com) - 1600+ 免费开源的高质量 SVG 图标，支持 SVG、Font、React、React Native、Flutter、Figma 和 Framer。
+- [Lineicons](https://lineicons.com) - 27000+ 多种风格的图标，其中核心图标集可免费用于网页和应用界面。
 
 ## 插图
 
@@ -75,6 +79,8 @@
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
 - [Blush](https://blush.design) - 免费可定制插图，带 Figma 插件。在您的设计中创建、编辑和使用插图。
 - [Open Peeps](https://www.openpeeps.com) - 手绘人物插图库，用于创建人物场景。可用于产品插图、营销、漫画等。
+- [illlustrations](https://illlustrations.co) - 120+ 开源插图，提供 AI、SVG、PNG、EPS 和 Figma 格式，可免费用于商业和个人项目。
+- [Ouch!](https://icons8.com/illustrations) - 免费的矢量、3D 和动画插图，下载前可自由改色和组合。
 
 ## 模板
 
@@ -82,6 +88,7 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 现代和极简的模板，用于构建您的下一个产品。使用 React、NextJS、TailwindCSS、Framer Motion 和 Typescript 构建。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
 - [Preline](https://preline.co) - 💵 一个开源的 Tailwind CSS 组件库，适用于各种需求。提供 UI 示例和区块、模板、插件、Figma 设计系统等。
+- [Cruip](https://cruip.com) - 💵 Tailwind CSS 落地页、网站和仪表板模板，提供 HTML、React、Next.js 和 Vue 版本。
 
 ## 摄影
 
@@ -95,6 +102,7 @@
 - [Little Visuals](https://littlevisuals.co) - 免费高分辨率图像。可以随意使用 - 免费商用。
 - [UI Faces](https://uifaces.co) - 为您的创意项目提供免费 AI 生成头像。
 - [Nappy](https://nappy.co) - 以黑人和棕色人种为主题的高分辨率精美照片，可免费用于个人和商业项目。
+- [Kaboompics](https://kaboompics.com) - 免费的图库照片和精选拍摄专题，可按每张图片的配色方案检索。
 - [Deposit Photos](https://depositphotos.com) - 💵 免费版权库存照片、矢量图像、视频和音乐。
 - [Freepik](https://www.freepik.com) - 💵 数百万免费矢量、PSD 文件、照片和 AI 生成图像。创意项目的优质资源。
 
@@ -104,6 +112,10 @@
 - [Inter](https://rsms.me/inter/) - 一个用于文本界面的可变字体家族。
 - [Fontshare](https://www.fontshare.com) - 来自 Indian Type Foundry 的免费字体服务，提供可用于个人和商业项目的优质字体。
 - [Uncut](https://uncut.wtf) - 精选的当代开源字体库，可免费下载使用。
+- [Open Foundry](https://open-foundry.com) - 精选开源字体展示，以印刷字体样本般的考究方式呈现。
+- [Fontsource](https://fontsource.org) - 2000+ 开源字体家族，以 npm 包形式提供，可自托管字体而无需依赖 CDN。
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - 第一家开源字体铸造厂，提供精心制作、可自由用于任何项目的字体。
+- [Geist](https://vercel.com/font) - Vercel 出品的开源无衬线、等宽和像素字体，专为面向开发者的界面设计。
 - [Labor and Wait](https://www.laborandwait.xyz) - 💵 购买优质、精选的商品和产品。
 - [I Love Typography](https://fonts.ilovetypography.com) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
@@ -125,6 +137,10 @@
 - [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
 - [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
+- [Radix Colors](https://www.radix-ui.com/colors) - 面向用户界面的 12 级色阶系统，提供配套的浅色、深色和透明度色阶。
+- [UI Colors](https://uicolors.app) - 从任意品牌色生成 Tailwind CSS 色阶，并在真实组件上预览效果。
+- [Khroma](https://www.khroma.co) - 根据你喜欢的颜色训练模型，持续生成可搜索和收藏的配色方案。
+- [Colour Contrast Checker](https://www.colourcontrast.cc) - 在调整前景色和背景色的同时，实时对照 WCAG 对比度标准进行检查。
 
 ## 工具
 
@@ -136,6 +152,12 @@
 - [Haikei](https://haikei.app) - 直接在浏览器中生成独特的 SVG 背景、色块、波浪等设计素材。
 - [ray.so](https://ray.so) - 由 Raycast 团队出品，将代码片段转换成可直接分享的精美图片。
 - [tldraw](https://www.tldraw.com) - 用于绘制图表、线框图和创意想法的协作式无限白板。
+- [Motion](https://motion.dev) - 面向 React、JavaScript 和 Vue 的生产级开源动画库。
+- [Excalidraw](https://excalidraw.com) - 虚拟白板工具，用于绘制手绘风格的图表、线框图和草图。
+- [Squoosh](https://squoosh.app) - 直接在浏览器中压缩和比较图片，可实时并排预览各种编码格式的效果。
+- [Animista](https://animista.net) - 浏览现成的 CSS 动画，调整参数后只复制需要的那部分代码。
+- [Utopia](https://utopia.fyi) - 流式字号与间距比例计算器，在视口之间平滑插值，而非在断点处跳变。
+- [MagicPattern](https://www.magicpattern.design) - 30+ 个背景、图案、渐变和不规则形状生成器，可导出为图片、SVG 或 CSS。
 - [Rotato](https://rotato.app) - 💵 几分钟内制作 3D 模型图像和视频。
 - [Spline](https://spline.design) - 💵 3D 设计和协作的地方。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
@@ -145,12 +167,17 @@
 - [Canva](https://www.canva.com) - 💵 使用 Canva 的拖放功能和专业布局轻松创建令人惊叹的设计。
 - [InVision](https://www.invisionapp.com) - 💵 为世界最佳用户体验提供支持的数字产品设计平台。
 - [Screen Studio](https://screen.studio) - 💵 macOS 屏幕录制工具，自动缩放和流畅动画，适合制作精致的产品演示。
+- [Jitter](https://jitter.video) - 💵 面向产品团队的动效设计工具，画布操作亲切，可导出视频或 Lottie。
 
 ## 书籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
 - [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
+- [Inclusive Components](https://inclusive-components.design) - 一个模式库，逐个拆解讲解如何以无障碍的方式构建常见界面组件。
+- [The Shape of Design](https://shapeofdesignbook.com) - Frank Chimero 关于设计工作背后手艺与意图的著作，可在线免费阅读。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
+- [Every Layout](https://every-layout.dev) - 💵 通过一组简单、可组合的布局原语，重新学习 CSS 布局。
+- [Animations on the Web](https://animations.dev) - 💵 Emil Kowalski 的互动课程，讲解让动画“手感对”的理论与实践。
 
 ## 社区
 
@@ -159,4 +186,8 @@
 - [Sketchfab](https://sketchfab.com) - Sketchfab 是一个 3D 资产网站，用于发布、分享、发现、购买和销售 3D、VR 和 AR 内容。
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
 - [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
+- [Typewolf](https://www.typewolf.com) - 追踪字体潮流：字体清单、案例图集，以及来自真实网站的排版灵感。
+- [The Component Gallery](https://component.gallery) - 界面组件资料库，收录来自公开设计系统的真实示例。
+- [Minimal Gallery](https://minimal.gallery) - 精选美观且实用的网站画廊，并提供每周精选摘要。
+- [One Page Love](https://onepagelove.com) - 9000+ 精选单页网站与页面区块示例，自 2008 年持续收录。
 - [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。


### PR DESCRIPTION
Adds 31 new resources to `README.md`, `README.zh.md`, `README.es.md`, `README.fr.md`, `README.de.md` and `README.ja.md`, keeping all six language versions in sync.

## What was added

| Section | Resources |
| --- | --- |
| UI Libraries | Ark UI, Tremor, Kokonut UI |
| Icons | Lineicons |
| Illustrations | illlustrations, Ouch! |
| Templates | Cruip 💵 |
| Photography | Kaboompics |
| Fonts | Open Foundry, Fontsource, The League of Moveable Type, Geist |
| Colors | Radix Colors, UI Colors, Khroma, Colour Contrast Checker |
| Tools | Motion, Excalidraw, Squoosh, Animista, Utopia, MagicPattern, Jitter 💵 |
| Books | Inclusive Components, The Shape of Design, Every Layout 💵, Animations on the Web 💵 |
| Communities | Typewolf, The Component Gallery, Minimal Gallery, One Page Love |

## How candidates were vetted

Roughly 60 candidates were collected and each one was loaded in a headless Chromium at 1440×900 and reviewed visually before any decision was made. Sites were rejected when the landing page was visually cluttered, buried under promo modals or ad units, or simply too bare to belong on a design list — and also when the page could not be rendered for review at all, so nothing went in unseen. Every URL that made the cut was additionally confirmed to load successfully.

## Formatting

- Follows the existing `- [Name](URL) - Description.` format.
- Free resources are placed alongside the other free entries in each section; paid ones are appended at the end of the section with the 💵 marker, matching the current convention.
- Descriptions were written natively for each language rather than machine-translated from the English line.

## Link validation

`npx markdown-link-check README.md` reports 9 dead links, all of them **pre-existing** entries that return 401/403/429 to automated checkers (Unsplash, Pexels, Pixabay, Freepik, Canva, Cult UI, vectorCraftr, brandcolors.net). None of the newly added links are among them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kp6tEpTC8sXCbxEixNeqv5)_