### PR TITLE
Add 25 visually-vetted design resources across all six language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,6 +40,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
 - [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
 - [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
+- [Kokonut UI](https://kokonutui.com) - Über 100 Open-Source-React-Komponenten mit Tailwind CSS und Motion, mit Live-Vorschauen und maschinenlesbarer Registry.
+- [Once UI](https://once-ui.com) - Ein Open-Source-Designsystem mit über 100 vorgestylten Komponenten, dessen Themes und Styles in einer einzigen Datei verwaltet werden.
+- [Tremor](https://www.tremor.so) - Über 35 vollständig quelloffene, barrierefreie React-Komponenten für Diagramme und Dashboards, gebaut mit Tailwind CSS und Radix UI.
 
 ## Icons
 
@@ -59,6 +62,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
+- [Radix Icons](https://www.radix-ui.com/icons) - Ein klarer Satz von 15×15-Icons vom Radix-Team, verfügbar für Figma, als SVG-Download und über npm.
+- [Pixel Icon Library](https://pixeliconlibrary.com) - Eine Open-Source-Sammlung pixeliger Icons, sorgfältig auf einem 24px-Raster für perfekte Ausrichtung und Konsistenz gezeichnet.
 
 ## Illustrationen
 
@@ -74,6 +79,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
 - [Blush](https://blush.design) - Kostenlose anpassbare Illustrationen mit Figma-Plugin. Erstellen, bearbeiten und verwenden Sie Illustrationen in Ihren Designs.
 - [Open Peeps](https://www.openpeeps.com) - Eine handgezeichnete Illustrationsbibliothek zum Erstellen von Szenen mit Menschen. Sie können sie in Produktillustration, Marketing, Comics und mehr verwenden.
+- [Open Doodles](https://www.opendoodles.com) - Ein kostenloser Satz quelloffener, handgezeichneter Illustrationen, die sich umfärben und zu eigenen Szenen kombinieren lassen.
 
 ## Vorlagen
 
@@ -81,6 +87,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Moderne und minimalistische Vorlagen für Ihr nächstes Produkt. Erstellt mit React, NextJS, TailwindCSS, Framer Motion und TypeScript.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
 - [Preline](https://preline.co) - 💵 Eine Open-Source Tailwind CSS-Komponentenbibliothek für alle Bedürfnisse. Kommt mit UI-Beispielen & Blöcken, Vorlagen, Plugins, Figma-Designsystem und mehr.
+- [Cruip](https://cruip.com) - 💵 Landingpages, Websites und Dashboards auf Basis von Tailwind CSS, umgesetzt in HTML, React, Next.js und Vue.
+- [Astro Themes](https://astro.build/themes) - Themes und Starter-Vorlagen für Astro-Websites, von Blogs und Dokumentationen bis zu Portfolios und Shops.
 
 ## Fotografie
 
@@ -108,6 +116,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
 - [Klim](https://klim.co.nz) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Eine unabhängige Schriftgießerei mit hochwertigen Schriften, kostenlos testbar vor dem Lizenzkauf.
+- [Open Foundry](https://open-foundry.com) - Eine kuratierte Auswahl herausragender Open-Source-Schriften, präsentiert zusammen mit den Geschichten ihrer Gestalter.
+- [Velvetyne](https://velvetyne.fr) - Eine freie Schriftgießerei, die Hunderte kostenlose, experimentelle und quelloffene Schriften veröffentlicht.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - Die erste Open-Source-Schriftgießerei, die seit 2009 die Gestaltungsstandards des Webs anhebt.
 
 ## Farben
 
@@ -124,6 +135,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
 - [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
 - [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
+- [Radix Colors](https://www.radix-ui.com/colors) - Ein wunderschönes, barrierefreies Farbsystem für Benutzeroberflächen mit 12-stufigen Skalen für helle und dunkle Modi.
+- [UI Colors](https://uicolors.app) - Erzeugt Tailwind-CSS-Farbskalen aus jeder Markenfarbe und zeigt sie in echten Komponenten, Dashboards und Diagrammen in der Vorschau.
 
 ## Werkzeuge
 
@@ -144,12 +157,20 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Canva](https://www.canva.com) - 💵 Erstellen Sie mühelos atemberaubende Designs mit Canvas Drag & Drop-Funktion und professionellen Layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digitale Produktdesign-Plattform für die weltbesten Benutzererfahrungen.
 - [Screen Studio](https://screen.studio) - 💵 macOS-Bildschirmrekorder mit automatischem Zoom und weichen Animationen für polierte Produkt-Demos.
+- [Motion](https://motion.dev) - Eine produktionsreife Animationsbibliothek für das Web unter MIT-Lizenz, verfügbar für React, JavaScript und Vue.
+- [Excalidraw](https://excalidraw.com) - Ein virtuelles Whiteboard für Diagramme, Wireframes und Ideen im handgezeichneten Stil, mit Live-Zusammenarbeit.
+- [tweakcn](https://tweakcn.com) - Ein visueller Theme-Editor für shadcn/ui – Farben, Typografie und Layouts mit Echtzeitvorschau anpassen und nach Tailwind exportieren.
+- [Squoosh](https://squoosh.app) - Bilder komprimieren und Codecs direkt nebeneinander vergleichen – vollständig im Browser.
+- [Wakamai Fondue](https://wakamaifondue.com) - Schrift hineinziehen und sehen, was sie kann – Glyphen, OpenType-Funktionen, variable Achsen und Sprachunterstützung.
 
 ## Bücher
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
 - [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Ein wunderschön gesetzter Typografie-Leitfaden für alle, die schreiben – vom Fließtext bis zum Seitenlayout.
+- [Inclusive Components](https://inclusive-components.design) - Eine Pattern-Bibliothek über den Entwurf barrierefreier, inklusiver Web-Oberflächen – Komponente für Komponente.
+- [Every Layout](https://every-layout.dev) - 💵 CSS-Layout neu lernen – mit einfachen, kombinierbaren Layout-Primitiven, die den Browser die Arbeit machen lassen.
 
 ## Communities
 
@@ -159,3 +180,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
 - [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
 - [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.
+- [Recent](https://recent.design) - Eine tägliche Auswahl herausragender Designs, Websites und Werkzeuge, nach Disziplin sortiert.
+- [Codrops](https://tympanus.net/codrops) - Ein Magazin für Webdesigner und -entwickler mit kreativen Demos, Tutorials und einer kuratierten Galerie herausragender Websites.
+- [The Component Gallery](https://component.gallery) - Ein aktuelles Verzeichnis von Interface-Komponenten, basierend auf echten Beispielen aus der Welt der Designsysteme.
+- [Dribbble](https://dribbble.com) - Eine Community, in der Designer ihre Arbeiten teilen und Teams Inspiration, Freelancer und Agenturen finden.

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
 - [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
+- [Kokonut UI](https://kokonutui.com) - Más de 100 componentes React de código abierto creados con Tailwind CSS y Motion, con vistas previas en vivo y un registro legible por máquinas.
+- [Once UI](https://once-ui.com) - Un sistema de diseño de código abierto con más de 100 componentes preestilizados, donde los temas y estilos se gestionan desde un solo archivo.
+- [Tremor](https://www.tremor.so) - Más de 35 componentes React accesibles y totalmente de código abierto para crear gráficos y paneles, construidos con Tailwind CSS y Radix UI.
 
 ## Iconos
 
@@ -59,6 +62,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
+- [Radix Icons](https://www.radix-ui.com/icons) - Un conjunto nítido de iconos de 15×15 del equipo de Radix, disponible para Figma, descarga SVG y npm.
+- [Pixel Icon Library](https://pixeliconlibrary.com) - Una colección de código abierto de iconos pixelados, dibujados meticulosamente sobre una cuadrícula de 24px para una alineación y coherencia perfectas.
 
 ## Ilustraciones
 
@@ -74,6 +79,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
 - [Blush](https://blush.design) - Ilustraciones personalizables gratuitas con Plugin de Figma. Crea, edita y usa ilustraciones en tus diseños.
 - [Open Peeps](https://www.openpeeps.com) - Una librería de ilustraciones dibujadas a mano para crear escenas de personas. Puedes usarlas en ilustración de productos, marketing, cómics y más.
+- [Open Doodles](https://www.opendoodles.com) - Un conjunto gratuito de ilustraciones dibujadas a mano y de código abierto que puedes recolorear y remezclar en tus propias escenas.
 
 ## Plantillas
 
@@ -81,6 +87,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Plantillas modernas y minimalistas para construir tu próximo producto. Construidas con React, NextJS, TailwindCSS, Framer Motion y Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
 - [Preline](https://preline.co) - 💵 Una librería de componentes Tailwind CSS de código abierto para cualquier necesidad. Viene con ejemplos y bloques UI, plantillas, plugins, sistema de diseño Figma y más.
+- [Cruip](https://cruip.com) - 💵 Landing pages, sitios web y paneles construidos sobre Tailwind CSS y programados en HTML, React, Next.js y Vue.
+- [Astro Themes](https://astro.build/themes) - Temas y plantillas iniciales para sitios Astro, desde blogs y documentación hasta portafolios y tiendas.
 
 ## Fotografía
 
@@ -108,6 +116,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
 - [Klim](https://klim.co.nz) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Una fundición tipográfica independiente con tipografías de alta calidad, gratis para probar antes de licenciarlas.
+- [Open Foundry](https://open-foundry.com) - Una muestra curada de tipografías de código abierto excepcionales, presentadas junto a las historias de quienes las crearon.
+- [Velvetyne](https://velvetyne.fr) - Una fundición tipográfica libre que publica cientos de tipografías gratuitas, experimentales y de código abierto.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - La primera fundición tipográfica de código abierto, elevando los estándares de diseño de la web desde 2009.
 
 ## Colores
 
@@ -124,6 +135,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
 - [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
 - [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un sistema de color precioso y accesible para interfaces de usuario, con escalas de 12 pasos diseñadas para los modos claro y oscuro.
+- [UI Colors](https://uicolors.app) - Genera escalas de color de Tailwind CSS a partir de cualquier color de marca y previsualízalas en componentes, paneles y gráficos reales.
 
 ## Herramientas
 
@@ -144,12 +157,20 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Canva](https://www.canva.com) - 💵 Crea diseños impresionantes fácilmente con la función de arrastrar y soltar de Canva y diseños profesionales.
 - [InVision](https://www.invisionapp.com) - 💵 Plataforma de diseño de productos digitales que impulsa las mejores experiencias de usuario del mundo.
 - [Screen Studio](https://screen.studio) - 💵 Grabador de pantalla para macOS con zoom automático y animaciones suaves para demos de producto pulidas.
+- [Motion](https://motion.dev) - Una biblioteca de animación de nivel de producción con licencia MIT para la web, disponible para React, JavaScript y Vue.
+- [Excalidraw](https://excalidraw.com) - Una pizarra virtual para bocetar diagramas, wireframes e ideas con estilo dibujado a mano, con colaboración en vivo.
+- [tweakcn](https://tweakcn.com) - Un editor visual de temas para shadcn/ui: personaliza colores, tipografía y diseños con vista previa en tiempo real y expórtalos a Tailwind.
+- [Squoosh](https://squoosh.app) - Comprime imágenes y compara códecs en paralelo, íntegramente en el navegador.
+- [Wakamai Fondue](https://wakamaifondue.com) - Suelta una fuente y descubre todo lo que puede hacer: glifos, características OpenType, ejes variables y soporte de idiomas.
 
 ## Libros
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Una guía de tipografía bellamente compuesta para cualquiera que escriba, del texto corrido a la maquetación de la página.
+- [Inclusive Components](https://inclusive-components.design) - Una biblioteca de patrones sobre cómo diseñar interfaces web accesibles e inclusivas, componente a componente.
+- [Every Layout](https://every-layout.dev) - 💵 Reaprende el diseño con CSS mediante primitivas de layout simples y componibles que dejan trabajar al navegador.
 
 ## Comunidades
 
@@ -159,3 +180,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
 - [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
 - [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.
+- [Recent](https://recent.design) - Una curaduría diaria de diseño, sitios web y herramientas excepcionales, ordenados por disciplina.
+- [Codrops](https://tympanus.net/codrops) - Una publicación para diseñadores y desarrolladores web, con demos creativas, tutoriales y una galería curada de sitios destacados.
+- [The Component Gallery](https://component.gallery) - Un repositorio actualizado de componentes de interfaz, basado en ejemplos reales del mundo de los sistemas de diseño.
+- [Dribbble](https://dribbble.com) - Una comunidad donde los diseñadores comparten su trabajo y los equipos encuentran inspiración, freelancers y agencias.

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,6 +40,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
 - [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
+- [Kokonut UI](https://kokonutui.com) - Plus de 100 composants React open source construits avec Tailwind CSS et Motion, avec aperçus en direct et registre lisible par les machines.
+- [Once UI](https://once-ui.com) - Un design system open source avec plus de 100 composants pré-stylés, dont les thèmes et styles se gèrent depuis un seul fichier.
+- [Tremor](https://www.tremor.so) - Plus de 35 composants React accessibles et entièrement open source pour créer graphiques et tableaux de bord, construits avec Tailwind CSS et Radix UI.
 
 ## Icônes
 
@@ -59,6 +62,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
+- [Radix Icons](https://www.radix-ui.com/icons) - Un ensemble net d'icônes 15×15 signé par l'équipe Radix, disponible pour Figma, en SVG et via npm.
+- [Pixel Icon Library](https://pixeliconlibrary.com) - Une collection open source d'icônes pixelisées, dessinées avec soin sur une grille de 24px pour un alignement et une cohérence parfaits.
 
 ## Illustrations
 
@@ -74,6 +79,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
 - [Blush](https://blush.design) - Illustrations personnalisables gratuites avec Plugin Figma. Créez, éditez et utilisez des illustrations dans vos designs.
 - [Open Peeps](https://www.openpeeps.com) - Une bibliothèque d'illustrations dessinées à la main pour créer des scènes de personnes. Vous pouvez les utiliser dans l'illustration de produit, marketing, bandes dessinées et plus.
+- [Open Doodles](https://www.opendoodles.com) - Un ensemble gratuit d'illustrations dessinées à la main et open source, que vous pouvez recolorer et remixer dans vos propres scènes.
 
 ## Modèles
 
@@ -81,6 +87,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modèles modernes et minimalistes pour construire votre prochain produit. Construits avec React, NextJS, TailwindCSS, Framer Motion et Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
 - [Preline](https://preline.co) - 💵 Une bibliothèque de composants Tailwind CSS open source pour tous les besoins. Livré avec des exemples et blocs UI, modèles, plugins, système de design Figma et plus.
+- [Cruip](https://cruip.com) - 💵 Landing pages, sites web et tableaux de bord construits sur Tailwind CSS et codés en HTML, React, Next.js et Vue.
+- [Astro Themes](https://astro.build/themes) - Thèmes et modèles de départ pour les sites Astro, du blog à la documentation en passant par les portfolios et les boutiques.
 
 ## Photographie
 
@@ -108,6 +116,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
 - [Klim](https://klim.co.nz) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Une fonderie typographique indépendante aux caractères de haute qualité, gratuits à essayer avant l'achat de licence.
+- [Open Foundry](https://open-foundry.com) - Une vitrine soignée de caractères open source d'exception, présentés avec l'histoire de celles et ceux qui les ont créés.
+- [Velvetyne](https://velvetyne.fr) - Une fonderie typographique libre qui publie des centaines de caractères gratuits, expérimentaux et open source.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - La première fonderie de polices open source, qui élève les standards de design du web depuis 2009.
 
 ## Couleurs
 
@@ -124,6 +135,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
 - [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
 - [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un superbe système de couleurs accessible pour les interfaces, avec des échelles de 12 niveaux pensées pour les modes clair et sombre.
+- [UI Colors](https://uicolors.app) - Générez des échelles de couleurs Tailwind CSS à partir de n'importe quelle couleur de marque et prévisualisez-les sur de vrais composants, tableaux de bord et graphiques.
 
 ## Outils
 
@@ -144,12 +157,20 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Canva](https://www.canva.com) - 💵 Créez facilement des designs époustouflants avec la fonction glisser-déposer de Canva et des mises en page professionnelles.
 - [InVision](https://www.invisionapp.com) - 💵 Plateforme de design de produit numérique alimentant les meilleures expériences utilisateur du monde.
 - [Screen Studio](https://screen.studio) - 💵 Enregistreur d'écran macOS avec zoom automatique et animations fluides pour des démos produit soignées.
+- [Motion](https://motion.dev) - Une bibliothèque d'animation web de qualité production sous licence MIT, disponible pour React, JavaScript et Vue.
+- [Excalidraw](https://excalidraw.com) - Un tableau blanc virtuel pour esquisser diagrammes, wireframes et idées façon dessin à la main, avec collaboration en direct.
+- [tweakcn](https://tweakcn.com) - Un éditeur de thème visuel pour shadcn/ui : personnalisez couleurs, typographie et mises en page avec un aperçu en temps réel, puis exportez vers Tailwind.
+- [Squoosh](https://squoosh.app) - Compressez des images et comparez les codecs côte à côte, entièrement dans le navigateur.
+- [Wakamai Fondue](https://wakamaifondue.com) - Déposez une police et découvrez tout ce qu'elle sait faire : glyphes, fonctionnalités OpenType, axes variables et langues prises en charge.
 
 ## Livres
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
+- [Butterick's Practical Typography](https://practicaltypography.com) - Un guide de typographie magnifiquement composé pour toute personne qui écrit, du texte courant à la mise en page.
+- [Inclusive Components](https://inclusive-components.design) - Une bibliothèque de patterns sur la conception d'interfaces web accessibles et inclusives, composant par composant.
+- [Every Layout](https://every-layout.dev) - 💵 Réapprenez la mise en page CSS grâce à des primitives simples et composables qui laissent le navigateur travailler.
 
 ## Communautés
 
@@ -159,3 +180,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
 - [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
 - [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.
+- [Recent](https://recent.design) - Une curation quotidienne de design, de sites web et d'outils d'exception, classés par discipline.
+- [Codrops](https://tympanus.net/codrops) - Une publication pour les designers et développeurs web, avec des démos créatives, des tutoriels et une galerie de sites remarquables.
+- [The Component Gallery](https://component.gallery) - Un référentiel à jour de composants d'interface, fondé sur des exemples réels issus des design systems.
+- [Dribbble](https://dribbble.com) - Une communauté où les designers partagent leur travail et où les équipes trouvent inspiration, freelances et agences.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,9 @@
 - [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
 - [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
 - [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
+- [Kokonut UI](https://kokonutui.com) - Tailwind CSS と Motion で作られた 100 以上のオープンソース React コンポーネント。ライブプレビューと機械可読なレジストリ付き。
+- [Once UI](https://once-ui.com) - 100 以上のスタイル済みコンポーネントを備えたオープンソースのデザインシステム。テーマとスタイルを 1 つのファイルで管理できます。
+- [Tremor](https://www.tremor.so) - チャートやダッシュボードを構築するための、完全オープンソースでアクセシブルな 35 以上の React コンポーネント。Tailwind CSS と Radix UI 製。
 
 ## アイコン
 
@@ -59,6 +62,8 @@
 - [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
+- [Radix Icons](https://www.radix-ui.com/icons) - Radix チームによる 15×15 の精緻なアイコンセット。Figma、SVG ダウンロード、npm で利用できます。
+- [Pixel Icon Library](https://pixeliconlibrary.com) - 24px グリッド上で丁寧に描かれた、オープンソースのピクセルアイコンコレクション。完璧な整列と一貫性を実現しています。
 
 ## イラスト
 
@@ -74,6 +79,7 @@
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
 - [Blush](https://blush.design) - Figma プラグイン付きの無料カスタマイズ可能イラスト。デザインでイラストを作成、編集、使用できます。
 - [Open Peeps](https://www.openpeeps.com) - 人々のシーンを作成するための手描きイラストライブラリ。製品イラスト、マーケティング、コミックなどで使用できます。
+- [Open Doodles](https://www.opendoodles.com) - 無料のオープンソース手描きイラスト集。色を変えて自由に組み合わせ、自分だけのシーンを作れます。
 
 ## テンプレート
 
@@ -81,6 +87,8 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 次の製品を構築するためのモダンでミニマリストなテンプレート。React、NextJS、TailwindCSS、Framer Motion、TypeScript で構築。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
 - [Preline](https://preline.co) - 💵 あらゆるニーズに対応するオープンソース Tailwind CSS コンポーネントライブラリ。UI サンプル＆ブロック、テンプレート、プラグイン、Figma デザインシステムなどが付属。
+- [Cruip](https://cruip.com) - 💵 Tailwind CSS で構築されたランディングページ、ウェブサイト、ダッシュボード。HTML、React、Next.js、Vue 版があります。
+- [Astro Themes](https://astro.build/themes) - Astro サイト向けのテーマとスターターテンプレート。ブログやドキュメントからポートフォリオ、ストアまで対応。
 
 ## 写真
 
@@ -108,6 +116,9 @@
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
 - [Klim](https://klim.co.nz) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 高品質な書体を手がける独立系フォントファウンドリ。ライセンス購入前に無料で試用可能。
+- [Open Foundry](https://open-foundry.com) - 優れたオープンソース書体を厳選して紹介するサイト。制作者たちのストーリーも併せて読めます。
+- [Velvetyne](https://velvetyne.fr) - 無料で実験的なオープンソース書体を数百点公開している、リブレ（自由）なタイプファウンドリ。
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - 最初のオープンソース・フォントファウンドリ。2009 年からウェブのデザイン水準を引き上げ続けています。
 
 ## 色
 
@@ -124,6 +135,8 @@
 - [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
 - [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
+- [Radix Colors](https://www.radix-ui.com/colors) - ユーザーインターフェース向けの美しくアクセシブルなカラーシステム。ライト／ダーク両モードに対応した 12 段階のスケールを提供。
+- [UI Colors](https://uicolors.app) - 任意のブランドカラーから Tailwind CSS のカラースケールを生成し、実際のコンポーネントやダッシュボード、チャート上でプレビューできます。
 
 ## ツール
 
@@ -144,12 +157,20 @@
 - [Canva](https://www.canva.com) - 💵 Canva のドラッグ＆ドロップ機能とプロフェッショナルレイアウトで素晴らしいデザインを簡単に作成。
 - [InVision](https://www.invisionapp.com) - 💵 世界最高のユーザー体験を推進するデジタル製品デザインプラットフォーム。
 - [Screen Studio](https://screen.studio) - 💵 自動ズームと滑らかなアニメーションを備えた macOS 向け画面録画ツール。洗練された製品デモに最適。
+- [Motion](https://motion.dev) - MIT ライセンスの本番運用可能なウェブアニメーションライブラリ。React、JavaScript、Vue に対応。
+- [Excalidraw](https://excalidraw.com) - 手描き風の図表・ワイヤーフレーム・アイデアをスケッチできる仮想ホワイトボード。リアルタイム共同編集にも対応。
+- [tweakcn](https://tweakcn.com) - shadcn/ui 用のビジュアルテーマエディタ。色・タイポグラフィ・レイアウトをリアルタイムプレビューで調整し、Tailwind に書き出せます。
+- [Squoosh](https://squoosh.app) - ブラウザ上だけで画像を圧縮し、コーデックを並べて比較できるツール。
+- [Wakamai Fondue](https://wakamaifondue.com) - フォントをドロップするだけで、その機能をすべて確認できます。グリフ、OpenType 機能、可変軸、対応言語まで。
 
 ## 書籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
 - [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
+- [Butterick's Practical Typography](https://practicaltypography.com) - 文章を書くすべての人のための、美しく組版されたタイポグラフィ入門。本文組みからページレイアウトまで扱います。
+- [Inclusive Components](https://inclusive-components.design) - アクセシブルでインクルーシブなウェブ UI の作り方を、コンポーネント単位で解説するパターンライブラリ。
+- [Every Layout](https://every-layout.dev) - 💵 シンプルで組み合わせ可能なレイアウトプリミティブを通じて、CSS レイアウトを学び直す本。ブラウザに仕事を任せる考え方が身につきます。
 
 ## コミュニティ
 
@@ -159,3 +180,7 @@
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
 - [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
 - [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。
+- [Recent](https://recent.design) - 優れたデザイン・ウェブサイト・ツールを毎日キュレーション。分野別に整理されています。
+- [Codrops](https://tympanus.net/codrops) - ウェブデザイナーとデベロッパー向けのメディア。創造的なデモ、チュートリアル、優れたサイトの厳選ギャラリーを掲載。
+- [The Component Gallery](https://component.gallery) - デザインシステムの実例をもとにした、常に更新されるインターフェースコンポーネントの資料集。
+- [Dribbble](https://dribbble.com) - デザイナーが作品を共有するコミュニティ。チームはインスピレーションやフリーランス・制作会社を見つけられます。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
 - [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
 - [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
+- [Kokonut UI](https://kokonutui.com) - 100+ open-source React components built with Tailwind CSS and Motion, with live previews and a machine-readable registry.
+- [Once UI](https://once-ui.com) - An open-source design system with 100+ pre-styled components, where themes and styles are managed from a single file.
+- [Tremor](https://www.tremor.so) - 35+ fully open-source, accessible React components for building charts and dashboards, built with Tailwind CSS and Radix UI.
 
 ## Icons
 
@@ -59,6 +62,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
+- [Radix Icons](https://www.radix-ui.com/icons) - A crisp set of 15×15 icons from the Radix team, available for Figma, SVG download and npm.
+- [Pixel Icon Library](https://pixeliconlibrary.com) - An open-source collection of pixelated icons, meticulously drawn on a 24px grid for perfect alignment and consistency.
 
 ## Illustrations
 
@@ -74,6 +79,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
 - [Blush](https://blush.design) - Free customizable illustrations with Figma Plugin. Create, edit, and use illustrations in your designs.
 - [Open Peeps](https://www.openpeeps.com) - A hand-drawn illustration library to create scenes of people. You can use them in product illustration, marketing, comics, and more.
+- [Open Doodles](https://www.opendoodles.com) - A free set of open-source, hand-drawn illustrations you can recolor and remix into your own scenes.
 
 ## Templates
 
@@ -81,6 +87,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modern and minimalist templates for building your next product. Built with React, NextJS, TailwindCSS, Framer Motion and Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
 - [Preline](https://preline.co) - 💵 An open-source Tailwind CSS components library for any needs. Comes with UI examples & blocks, templates, plugins, Figma design system and more.
+- [Cruip](https://cruip.com) - 💵 Landing pages, websites and dashboards built on Tailwind CSS and coded in HTML, React, Next.js and Vue.
+- [Astro Themes](https://astro.build/themes) - Themes and starter templates for Astro sites, from blogs and documentation to portfolios and storefronts.
 
 ## Photography
 
@@ -108,6 +116,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
 - [Klim](https://klim.co.nz) - 💵 Shop quality, curated fonts from indie font foundries.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 An independent type foundry with high-quality typefaces, free to try before you license them.
+- [Open Foundry](https://open-foundry.com) - A curated showcase of exceptional open-source typefaces, presented alongside the stories of the people who made them.
+- [Velvetyne](https://velvetyne.fr) - A libre type foundry publishing hundreds of free, experimental and open-source typefaces.
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - The first open-source font foundry, raising the design standards of the web since 2009.
 
 ## Colors
 
@@ -124,6 +135,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
 - [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
 - [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
+- [Radix Colors](https://www.radix-ui.com/colors) - A gorgeous, accessible color system for user interfaces, with 12-step scales designed for both light and dark modes.
+- [UI Colors](https://uicolors.app) - Generate Tailwind CSS color scales from any brand color and preview them on real components, dashboards and charts.
 
 ## Tools
 
@@ -144,12 +157,20 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Canva](https://www.canva.com) - 💵 Create stunning designs easily with Canva's drag-and-drop feature and professional layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digital product design platform powering the world's best user experiences.
 - [Screen Studio](https://screen.studio) - 💵 macOS screen recorder with automatic zoom and smooth animations for polished product demos.
+- [Motion](https://motion.dev) - A production-grade, MIT-licensed animation library for the web, available for React, JavaScript and Vue.
+- [Excalidraw](https://excalidraw.com) - A virtual whiteboard for sketching hand-drawn-style diagrams, wireframes and ideas, with live collaboration.
+- [tweakcn](https://tweakcn.com) - A visual theme editor for shadcn/ui — customize colors, typography and layouts with a real-time preview, then export to Tailwind.
+- [Squoosh](https://squoosh.app) - Compress images and compare codecs side by side, entirely in the browser.
+- [Wakamai Fondue](https://wakamaifondue.com) - Drop in a font and find out what it can do — glyphs, OpenType features, variable axes and language support.
 
 ## Books
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
+- [Butterick's Practical Typography](https://practicaltypography.com) - A beautifully typeset guide to typography for anyone who writes, from body text to page layout.
+- [Inclusive Components](https://inclusive-components.design) - A pattern library about designing accessible, inclusive web interfaces, one component at a time.
+- [Every Layout](https://every-layout.dev) - 💵 Relearn CSS layout through simple, composable layout primitives that let the browser do the work.
 
 ## Communities
 
@@ -159,3 +180,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
 - [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
 - [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.
+- [Recent](https://recent.design) - A daily curation of exceptional design, websites and tools, sorted by discipline.
+- [Codrops](https://tympanus.net/codrops) - A publication for web designers and developers, with creative demos, tutorials and a curated gallery of standout sites.
+- [The Component Gallery](https://component.gallery) - An up-to-date repository of interface components, based on real examples from the world of design systems.
+- [Dribbble](https://dribbble.com) - A community where designers share their work and where teams find inspiration, freelancers and agencies.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,9 @@
 - [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
 - [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
 - [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
+- [Kokonut UI](https://kokonutui.com) - 100+ 个使用 Tailwind CSS 和 Motion 构建的开源 React 组件，提供实时预览和机器可读的组件注册表。
+- [Once UI](https://once-ui.com) - 开源设计系统，包含 100+ 个预置样式的组件，主题和样式都在同一个文件中管理。
+- [Tremor](https://www.tremor.so) - 35+ 个完全开源、无障碍的 React 组件，用于构建图表和仪表板，基于 Tailwind CSS 和 Radix UI 构建。
 
 ## 图标
 
@@ -60,6 +63,8 @@
 
 - [React Icons](https://react-icons.github.io/react-icons/) - 使用 react-icons 轻松在 React 项目中包含流行图标。
 - [Iconoir](https://iconoir.com) - 1600+ 免费开源的高质量 SVG 图标，支持 SVG、Font、React、React Native、Flutter、Figma 和 Framer。
+- [Radix Icons](https://www.radix-ui.com/icons) - 由 Radix 团队打造的 15×15 精致图标集，提供 Figma、SVG 下载和 npm 三种使用方式。
+- [Pixel Icon Library](https://pixeliconlibrary.com) - 开源像素风图标集合，在 24px 网格上精心绘制，保证完美的对齐和一致性。
 
 ## 插图
 
@@ -75,6 +80,7 @@
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
 - [Blush](https://blush.design) - 免费可定制插图，带 Figma 插件。在您的设计中创建、编辑和使用插图。
 - [Open Peeps](https://www.openpeeps.com) - 手绘人物插图库，用于创建人物场景。可用于产品插图、营销、漫画等。
+- [Open Doodles](https://www.opendoodles.com) - 免费的开源手绘插图集，可以自由改色并重新组合成属于你的场景。
 
 ## 模板
 
@@ -82,6 +88,8 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 现代和极简的模板，用于构建您的下一个产品。使用 React、NextJS、TailwindCSS、Framer Motion 和 Typescript 构建。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
 - [Preline](https://preline.co) - 💵 一个开源的 Tailwind CSS 组件库，适用于各种需求。提供 UI 示例和区块、模板、插件、Figma 设计系统等。
+- [Cruip](https://cruip.com) - 💵 基于 Tailwind CSS 的落地页、网站和仪表板模板，提供 HTML、React、Next.js 和 Vue 版本。
+- [Astro Themes](https://astro.build/themes) - Astro 网站的主题和起始模板，涵盖博客、文档、作品集和电商店面等场景。
 
 ## 摄影
 
@@ -109,6 +117,9 @@
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
 - [Klim](https://klim.co.nz) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 独立字体工作室出品的高品质字体，购买授权前可免费试用。
+- [Open Foundry](https://open-foundry.com) - 精选的优秀开源字体展示平台，同时呈现字体背后设计者的故事。
+- [Velvetyne](https://velvetyne.fr) - 自由字体铸造厂，发布数百款免费、实验性的开源字体。
+- [The League of Moveable Type](https://www.theleagueofmoveabletype.com) - 第一家开源字体铸造厂，自 2009 年起持续提升网页的设计水准。
 
 ## 颜色
 
@@ -125,6 +136,8 @@
 - [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
 - [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
+- [Radix Colors](https://www.radix-ui.com/colors) - 为用户界面打造的精美无障碍色彩系统，提供同时适配亮色和暗色模式的 12 级色阶。
+- [UI Colors](https://uicolors.app) - 从任意品牌色生成 Tailwind CSS 色阶，并在真实的组件、仪表板和图表上预览效果。
 
 ## 工具
 
@@ -145,12 +158,20 @@
 - [Canva](https://www.canva.com) - 💵 使用 Canva 的拖放功能和专业布局轻松创建令人惊叹的设计。
 - [InVision](https://www.invisionapp.com) - 💵 为世界最佳用户体验提供支持的数字产品设计平台。
 - [Screen Studio](https://screen.studio) - 💵 macOS 屏幕录制工具，自动缩放和流畅动画，适合制作精致的产品演示。
+- [Motion](https://motion.dev) - 生产级的 MIT 协议网页动画库，提供 React、JavaScript 和 Vue 版本。
+- [Excalidraw](https://excalidraw.com) - 用于绘制手绘风格图表、线框图和想法的虚拟白板，支持实时协作。
+- [tweakcn](https://tweakcn.com) - shadcn/ui 的可视化主题编辑器 —— 实时预览下调整颜色、排版和布局，并导出为 Tailwind 配置。
+- [Squoosh](https://squoosh.app) - 在浏览器中直接压缩图片，并并排对比不同编码格式的效果。
+- [Wakamai Fondue](https://wakamaifondue.com) - 拖入一个字体文件，就能看清它的全部能力 —— 字形、OpenType 特性、可变轴和语言支持。
 
 ## 书籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
 - [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
+- [Butterick's Practical Typography](https://practicaltypography.com) - 为所有写作者准备的排版指南，本身排印精美，内容从正文字体一路讲到页面布局。
+- [Inclusive Components](https://inclusive-components.design) - 一个关于如何设计无障碍、包容性网页界面的模式库，逐个组件深入讲解。
+- [Every Layout](https://every-layout.dev) - 💵 通过简单、可组合的布局原语重新学习 CSS 布局，把计算交还给浏览器。
 
 ## 社区
 
@@ -160,3 +181,7 @@
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
 - [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
 - [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。
+- [Recent](https://recent.design) - 每日精选的优秀设计、网站和工具，按设计领域分类整理。
+- [Codrops](https://tympanus.net/codrops) - 面向网页设计师和开发者的刊物，提供创意演示、教程以及精选的优秀网站画廊。
+- [The Component Gallery](https://component.gallery) - 持续更新的界面组件资料库，收录来自各类设计系统的真实案例。
+- [Dribbble](https://dribbble.com) - 设计师分享作品的社区，团队也能在这里寻找灵感、自由职业者和设计机构。


### PR DESCRIPTION
## Summary

Adds 25 new resources to every language README (`README.md`, `.zh`, `.es`, `.fr`, `.de`, `.ja`), covering nine of the ten categories.

Because this list is about design, every candidate was **rendered in a headless Chromium at 1280×800 and reviewed visually** before being included — not just checked for a 200 response. The bar was real design craft: intentional typography, art direction, and a homepage that isn't dominated by ad units or default framework styling.

## Additions

| Category | Added |
| --- | --- |
| UI Libraries | Kokonut UI, Once UI, Tremor |
| Icons | Radix Icons, Pixel Icon Library |
| Illustrations | Open Doodles |
| Templates | Cruip 💵, Astro Themes |
| Fonts | Open Foundry, Velvetyne, The League of Moveable Type |
| Colors | Radix Colors, UI Colors |
| Tools | Motion, Excalidraw, tweakcn, Squoosh, Wakamai Fondue |
| Books | Butterick's Practical Typography, Inclusive Components, Every Layout 💵 |
| Communities | Recent, Codrops, The Component Gallery, Dribbble |

Photography got no additions this round — every free-stock candidate reviewed (Picjumbo, Gratisography, ISO Republic, Kaboompics) led with a Shutterstock/iStock ad strip or a modal over the hero, which didn't clear the bar.

## Rejected after visual review

Screened but not included, so the reasoning is on the record: HyperUI and Flowbite (generic docs-page styling, ad units in the hero), Bootstrap Icons and Font Awesome (plain or interstitial-blocked), illlustrations.co (ad overlay on load), Leonardo and Typescale (functional but visually plain), Vercel Templates (now mostly AI-agent starters, not design templates), Reshot (service retiring).

`pqoqubbw/icons` was dropped for a different reason — it now redirects to `lucide-animated.com`, which the list already carries.

## Notes

- Placement follows the existing convention: appended to the end of the relevant category, with 💵 on paid resources.
- Descriptions are written natively in each of the six languages rather than machine-translated from the English.
- All 25 URLs return 200. `npx markdown-link-check README.md` reports 10 "dead" links; 9 are pre-existing entries returning 401/403/429 to bots (Unsplash, Pexels, Pixabay, Freepik, Canva, Cult UI, vectorCraftr, Brand Colors) and the 10th is the newly-added Dribbble, whose 202 is its standard bot challenge — it renders normally in a browser.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjbnKx2i5TG3JGrwytCAks)_