### PR TITLE
Add 30 visually vetted design resources across all six language READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,6 +40,10 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [React Bits](https://reactbits.dev) - Animierte React-Komponenten, Hintergründe und Texteffekte zum direkten Einbinden, verfügbar in JS/TS- und Tailwind/CSS-Varianten.
 - [Base UI](https://base-ui.com) - Ungestylte, barrierefreie UI-Komponenten für Design-Systeme, von den Machern von Radix, Floating UI und Material UI.
 - [Park UI](https://park-ui.com) - Schön gestaltete Komponenten auf Basis von Ark UI und Panda CSS, nutzbar mit React, Solid und Vue.
+- [Nuxt UI](https://ui.nuxt.com) - Eine umfassende Komponentenbibliothek für Vue und Nuxt mit über 125 barrierefreien, mit Tailwind CSS gestalteten Komponenten.
+- [Ark UI](https://ark-ui.com) - Eine Headless-Bibliothek mit über 45 barrierefreien Komponenten für React, Solid, Vue und Svelte – bereit für das eigene Designsystem.
+- [Flowbite](https://flowbite.com) - Eine Open-Source-Bibliothek mit über 600 UI-Komponenten, Sektionen und Seiten auf Basis von Tailwind CSS, gestaltet in Figma.
+- [Once UI](https://once-ui.com) - Ein Open-Source-Designsystem für Indie-Creator mit über 100 Komponenten und zentraler Theme-Verwaltung in einer einzigen Datei.
 
 ## Icons
 
@@ -59,6 +63,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [SVGL](https://svgl.app) - Eine Bibliothek mit Marken-Logos als SVG, bereit zum Kopieren, Herunterladen oder Einbinden ins Framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Über 44k Premium-Qualität SVG-Icons, regelmäßig für UIs, Präsentationen und Druckprojekte aktualisiert.
 - [Iconoir](https://iconoir.com) - Über 1600 kostenlose, quelloffene SVG-Icons für SVG, Font, React, React Native, Flutter, Figma und Framer.
+- [Font Awesome](https://fontawesome.com) - Die bekannteste Icon-Bibliothek des Webs mit Tausenden Icons in mehreren Stilen, nutzbar als Webfont oder SVG.
+- [OpenMoji](https://openmoji.org) - Open-Source-Emojis für Designer und Entwickler – als SVG, PNG und Schriftart, farbig oder als schwarze Outline.
+- [Lineicons](https://lineicons.com) - Über 27.000 kostenlose und Premium-Icons in mehreren Stilen, inklusive Figma-Dateien und fertiger Pakete für gängige Frameworks.
 
 ## Illustrationen
 
@@ -74,6 +81,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Shapefest](https://shapefest.com) - 💵 Über 100K transparente PNG-Bilder schöner 3D-Objekte.
 - [Blush](https://blush.design) - Kostenlose anpassbare Illustrationen mit Figma-Plugin. Erstellen, bearbeiten und verwenden Sie Illustrationen in Ihren Designs.
 - [Open Peeps](https://www.openpeeps.com) - Eine handgezeichnete Illustrationsbibliothek zum Erstellen von Szenen mit Menschen. Sie können sie in Produktillustration, Marketing, Comics und mehr verwenden.
+- [Open Doodles](https://www.opendoodles.com) - Ein kostenloses, quelloffenes Set handgezeichneter Illustrationen, das sich umfärben, skalieren und remixen lässt.
+- [Ouch!](https://icons8.com/illustrations) - Vektor-, 3D- und animierte Illustrationen von Icons8, direkt im Browser bearbeitbar und als SVG oder PNG herunterladbar.
 
 ## Vorlagen
 
@@ -81,6 +90,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Moderne und minimalistische Vorlagen für Ihr nächstes Produkt. Erstellt mit React, NextJS, TailwindCSS, Framer Motion und TypeScript.
 - [Shuffle](https://shuffle.dev/) - 💵 Erstellen Sie einfach Landingpages, Dashboards und E-Commerce-Vorlagen.
 - [Preline](https://preline.co) - 💵 Eine Open-Source Tailwind CSS-Komponentenbibliothek für alle Bedürfnisse. Kommt mit UI-Beispielen & Blöcken, Vorlagen, Plugins, Figma-Designsystem und mehr.
+- [TailAdmin](https://tailadmin.com) - Eine quelloffene Admin-Dashboard-Vorlage mit Tailwind CSS für HTML, React, Next.js, Vue, Angular und Laravel.
+- [Cruip](https://cruip.com) - 💵 Landingpage-, Website- und Dashboard-Vorlagen mit Tailwind CSS, umgesetzt in HTML, React, Next.js und Vue.
 
 ## Fotografie
 
@@ -96,6 +107,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Nappy](https://nappy.co) - Schöne hochauflösende Fotos von Schwarzen und Brown People, kostenlos für private und kommerzielle Nutzung.
 - [Deposit Photos](https://depositphotos.com) - 💵 Lizenzfreie Stock-Fotos, Vektorbilder, Videos und Musik.
 - [Freepik](https://www.freepik.com) - 💵 Millionen kostenloser Vektoren, PSD-Dateien, Fotos und KI-generierter Bilder. Premium-Ressourcen für Ihre kreativen Projekte.
+- [Kaboompics](https://kaboompics.com) - Kostenlose Stockfotos und kuratierte Fotoserien zur kommerziellen Nutzung, durchsuchbar nach Farbpalette.
 
 ## Schriftarten
 
@@ -108,6 +120,9 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [T26](https://www.t26.com) - 💵 Kaufen Sie gut gestaltete Schriften.
 - [Klim](https://klim.co.nz) - 💵 Kaufen Sie kuratierte Qualitätsschriften von unabhängigen Schriftgießereien.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Eine unabhängige Schriftgießerei mit hochwertigen Schriften, kostenlos testbar vor dem Lizenzkauf.
+- [Modern Font Stacks](https://modernfontstacks.com) - System-Font-Stacks als CSS, nach Schriftklassifikation sortiert – sofortiges Rendering ganz ohne Downloads.
+- [Fontpair](https://www.fontpair.co) - Kuratierte Google-Fonts-Kombinationen mit einem Playground, um Schrift, Farben und Icons gemeinsam zu testen.
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 Schriften kaufen, solange sie noch in Arbeit sind – zum günstigeren Preis und mit allen künftigen Updates gratis.
 
 ## Farben
 
@@ -124,6 +139,8 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Happy Hues](https://www.happyhues.co) - Kuratierte Farbpaletten im Kontext einer echten Seite, damit sichtbar wird, wo jede Farbe hingehört.
 - [Huemint](https://huemint.com) - Farbpaletten-Generator auf Basis von maschinellem Lernen für Marken, Websites und Grafiken.
 - [OKLCH Color Picker](https://oklch.com) - Farbwähler und Konverter für den OKLCH-Farbraum, mit Kontrastprüfung und P3-Gamut-Vorschau.
+- [Radix Colors](https://www.radix-ui.com/colors) - Ein wunderschönes, barrierefreies Farbsystem für Interfaces – mit 12-stufigen Skalen und automatischem Dark Mode.
+- [UI Colors](https://uicolors.app) - Tailwind-CSS-Farbgenerator, der die Palette an echten Komponenten zeigt und die Konfiguration exportiert.
 
 ## Werkzeuge
 
@@ -144,12 +161,21 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Canva](https://www.canva.com) - 💵 Erstellen Sie mühelos atemberaubende Designs mit Canvas Drag & Drop-Funktion und professionellen Layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digitale Produktdesign-Plattform für die weltbesten Benutzererfahrungen.
 - [Screen Studio](https://screen.studio) - 💵 macOS-Bildschirmrekorder mit automatischem Zoom und weichen Animationen für polierte Produkt-Demos.
+- [Open Props](https://open-props.style) - Aufgewertete CSS-Variablen: sorgfältig gestaltete Design-Tokens für Farben, Verläufe, Schatten, Easings und mehr.
+- [Hero Patterns](https://heropatterns.com) - Eine Sammlung wiederholbarer SVG-Hintergrundmuster, in Farbe und Deckkraft anpassbar.
+- [MagicPattern](https://www.magicpattern.design) - Über 30 Generatoren für Hintergründe, Muster, Verläufe und weitere Grafiken – exportierbar als Bild, SVG oder CSS.
+- [Checklist Design](https://www.checklist.design) - Sammlungen von Best Practices für Websites, Apps, Komponenten und Flows – damit vor dem Launch jedes Detail stimmt.
+- [The Component Gallery](https://component.gallery) - Ein Nachschlagewerk für Interface-Komponenten mit echten Beispielen aus Dutzenden öffentlichen Designsystemen.
 
 ## Bücher
 
 - [The Book of Shaders](https://thebookofshaders.com) - Dies ist eine sanfte Schritt-für-Schritt-Anleitung durch das abstrakte und komplexe Universum der Fragment-Shader.
 - [Laws of UX](https://lawsofux.com) - Eine Sammlung psychologischer Prinzipien, die beim Gestalten von Benutzeroberflächen helfen.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Lassen Sie Ihre Ideen großartig aussehen, ohne auf einen Designer angewiesen zu sein.
+- [Practical Typography](https://practicaltypography.com) - Matthew Buttericks Buch über Typografie für alltägliche Dokumente und Interfaces – online kostenlos lesbar.
+- [Inclusive Components](https://inclusive-components.design) - Eine Pattern-Bibliothek darüber, wie man barrierefreie, inklusive Interface-Komponenten Stück für Stück gestaltet.
+- [Every Layout](https://every-layout.dev) - 💵 CSS-Layout neu lernen – anhand einfacher, kombinierbarer Layout-Primitive.
+- [Growth.Design](https://growth.design) - Produkt-Fallstudien im Comic-Format, die die Psychologie hinter großartigen User Experiences beleuchten.
 
 ## Communities
 
@@ -159,3 +185,7 @@ Auch verfügbar in: [English](README.md) | [中文](README.zh.md) | [Español](R
 - [Pinterest](https://pinterest.com) - Eine visuelle Such- und Entdeckungsplattform, wo Menschen Inspiration finden, Ideen kuratieren und Produkte kaufen—alles an einem positiven Ort online.
 - [Awwwards](https://www.awwwards.com) - Auszeichnungen für Design, Kreativität und Innovation im Internet, mit einem Verzeichnis der besten Websites.
 - [Mobbin](https://mobbin.com) - 💵 Eine durchsuchbare Bibliothek echter Screens aus Mobile- und Web-Apps als UI- und UX-Inspiration.
+- [Cosmos](https://www.cosmos.so) - Ein Raum für visuelle Entdeckungen, um Design-Inspiration zu sammeln, zu ordnen und zu teilen.
+- [Savee](https://savee.it) - Von Designern kuratierte Inspiration – mit Apps und Browser-Erweiterungen zum Sammeln visueller Referenzen.
+- [Typewolf](https://www.typewolf.com) - Was in der Typografie angesagt ist: reale Schriftkombinationen, Lookbooks und Lernressourcen.
+- [One Page Love](https://onepagelove.com) - Eine kuratierte Galerie von One-Page-Websites, Sektionen und Vorlagen – handverlesen seit 2008.

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,10 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [React Bits](https://reactbits.dev) - Componentes animados de React, fondos y efectos de texto listos para usar, disponibles en variantes JS/TS y Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Componentes UI sin estilos y accesibles para crear sistemas de diseño, de los creadores de Radix, Floating UI y Material UI.
 - [Park UI](https://park-ui.com) - Componentes bellamente diseñados construidos con Ark UI y Panda CSS que funcionan con React, Solid y Vue.
+- [Nuxt UI](https://ui.nuxt.com) - Una completa biblioteca de componentes para Vue y Nuxt con más de 125 componentes accesibles y estilizados con Tailwind CSS.
+- [Ark UI](https://ark-ui.com) - Una biblioteca headless con más de 45 componentes accesibles para React, Solid, Vue y Svelte, lista para tu propio sistema de diseño.
+- [Flowbite](https://flowbite.com) - Una biblioteca de código abierto con más de 600 componentes, secciones y páginas construidos con Tailwind CSS y diseñados en Figma.
+- [Once UI](https://once-ui.com) - Un sistema de diseño de código abierto para creadores independientes, con más de 100 componentes y temas gestionados desde un solo archivo.
 
 ## Iconos
 
@@ -59,6 +63,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [SVGL](https://svgl.app) - Una biblioteca de logotipos SVG de marcas, lista para copiar, descargar o usar en tu framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Más de 44k iconos SVG de calidad premium, actualizados regularmente para UIs, presentaciones y proyectos impresos.
 - [Iconoir](https://iconoir.com) - Más de 1600 iconos SVG gratuitos y de código abierto, disponibles para SVG, Font, React, React Native, Flutter, Figma y Framer.
+- [Font Awesome](https://fontawesome.com) - La biblioteca de iconos de referencia en internet, con miles de iconos en varios estilos, usables como fuente web o SVG.
+- [OpenMoji](https://openmoji.org) - Emojis de código abierto para diseñadores y desarrolladores, disponibles en SVG, PNG y fuentes, a color o en contorno negro.
+- [Lineicons](https://lineicons.com) - Más de 27.000 iconos gratuitos y premium en varios estilos, con archivos de Figma y paquetes listos para los frameworks más usados.
 
 ## Ilustraciones
 
@@ -74,6 +81,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Shapefest](https://shapefest.com) - 💵 Más de 100K imágenes PNG transparentes de hermosos objetos 3D.
 - [Blush](https://blush.design) - Ilustraciones personalizables gratuitas con Plugin de Figma. Crea, edita y usa ilustraciones en tus diseños.
 - [Open Peeps](https://www.openpeeps.com) - Una librería de ilustraciones dibujadas a mano para crear escenas de personas. Puedes usarlas en ilustración de productos, marketing, cómics y más.
+- [Open Doodles](https://www.opendoodles.com) - Un conjunto gratuito de ilustraciones dibujadas a mano y de código abierto que puedes recolorear, redimensionar y remezclar.
+- [Ouch!](https://icons8.com/illustrations) - Ilustraciones vectoriales, 3D y animadas de Icons8, editables en el navegador y descargables en SVG o PNG.
 
 ## Plantillas
 
@@ -81,6 +90,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Plantillas modernas y minimalistas para construir tu próximo producto. Construidas con React, NextJS, TailwindCSS, Framer Motion y Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Crea fácilmente páginas de aterrizaje, dashboards y plantillas de e-commerce.
 - [Preline](https://preline.co) - 💵 Una librería de componentes Tailwind CSS de código abierto para cualquier necesidad. Viene con ejemplos y bloques UI, plantillas, plugins, sistema de diseño Figma y más.
+- [TailAdmin](https://tailadmin.com) - Una plantilla de panel de administración de código abierto con Tailwind CSS para HTML, React, Next.js, Vue, Angular y Laravel.
+- [Cruip](https://cruip.com) - 💵 Plantillas de landing pages, sitios web y paneles con Tailwind CSS, codificadas en HTML, React, Next.js y Vue.
 
 ## Fotografía
 
@@ -96,6 +107,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Nappy](https://nappy.co) - Hermosas fotos en alta resolución de personas negras y morenas, gratis para uso personal y comercial.
 - [Deposit Photos](https://depositphotos.com) - 💵 Fotos de stock libres de derechos, imágenes vectoriales, videos y música.
 - [Freepik](https://www.freepik.com) - 💵 Millones de vectores gratuitos, archivos PSD, fotos e imágenes generadas por IA. Recursos premium para tus proyectos creativos.
+- [Kaboompics](https://kaboompics.com) - Fotos de stock gratuitas y sesiones curadas para uso comercial, con búsqueda por paleta de colores.
 
 ## Fuentes
 
@@ -108,6 +120,9 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [T26](https://www.t26.com) - 💵 Compra fuentes bien diseñadas.
 - [Klim](https://klim.co.nz) - 💵 Compra fuentes de calidad y curadas de fundiciones tipográficas independientes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Una fundición tipográfica independiente con tipografías de alta calidad, gratis para probar antes de licenciarlas.
+- [Modern Font Stacks](https://modernfontstacks.com) - CSS de pilas de fuentes del sistema organizadas por clasificación tipográfica, para renderizar al instante sin descargas.
+- [Fontpair](https://www.fontpair.co) - Combinaciones curadas de Google Fonts con un espacio para probar tipografía, colores e iconos a la vez.
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 Compra tipografías aún en desarrollo a un precio más bajo y recibe gratis todas sus actualizaciones futuras.
 
 ## Colores
 
@@ -124,6 +139,8 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Happy Hues](https://www.happyhues.co) - Paletas de colores curadas mostradas en contexto sobre una página real, para ver dónde va cada color.
 - [Huemint](https://huemint.com) - Generador de paletas de color con aprendizaje automático para marcas, sitios web y gráficos.
 - [OKLCH Color Picker](https://oklch.com) - Selector y conversor de color para el espacio OKLCH, con verificación de contraste y vista previa de gama P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un sistema de color precioso y accesible para interfaces, con escalas de 12 pasos y modo oscuro automático.
+- [UI Colors](https://uicolors.app) - Generador de colores para Tailwind CSS que previsualiza tu paleta sobre componentes reales y exporta la configuración.
 
 ## Herramientas
 
@@ -144,12 +161,21 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Canva](https://www.canva.com) - 💵 Crea diseños impresionantes fácilmente con la función de arrastrar y soltar de Canva y diseños profesionales.
 - [InVision](https://www.invisionapp.com) - 💵 Plataforma de diseño de productos digitales que impulsa las mejores experiencias de usuario del mundo.
 - [Screen Studio](https://screen.studio) - 💵 Grabador de pantalla para macOS con zoom automático y animaciones suaves para demos de producto pulidas.
+- [Open Props](https://open-props.style) - Variables CSS mejoradas: tokens de diseño cuidadosamente elaborados para colores, degradados, sombras, easings y más.
+- [Hero Patterns](https://heropatterns.com) - Una colección de patrones de fondo SVG repetibles, personalizables en color y opacidad.
+- [MagicPattern](https://www.magicpattern.design) - Más de 30 generadores de fondos, patrones, degradados y otros gráficos, exportables como imagen, SVG o CSS.
+- [Checklist Design](https://www.checklist.design) - Colecciones de buenas prácticas para sitios, apps, componentes y flujos, para revisar cada detalle antes de publicar.
+- [The Component Gallery](https://component.gallery) - Una referencia de componentes de interfaz con ejemplos reales extraídos de decenas de sistemas de diseño públicos.
 
 ## Libros
 
 - [The Book of Shaders](https://thebookofshaders.com) - Esta es una guía gentil paso a paso a través del universo abstracto y complejo de los Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Una colección de principios de psicología que los diseñadores pueden considerar al crear interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Haz que tus ideas se vean increíbles, sin depender de un diseñador.
+- [Practical Typography](https://practicaltypography.com) - El libro de Matthew Butterick sobre tipografía para documentos e interfaces del día a día, de lectura gratuita en línea.
+- [Inclusive Components](https://inclusive-components.design) - Una biblioteca de patrones sobre cómo diseñar componentes de interfaz accesibles e inclusivos, pieza a pieza.
+- [Every Layout](https://every-layout.dev) - 💵 Reaprende el layout en CSS a través de un conjunto de primitivas simples y componibles.
+- [Growth.Design](https://growth.design) - Casos de estudio de producto contados como cómics, que exploran la psicología detrás de las grandes experiencias de usuario.
 
 ## Comunidades
 
@@ -159,3 +185,7 @@ También disponible en: [English](README.md) | [中文](README.zh.md) | [França
 - [Pinterest](https://pinterest.com) - Una plataforma de búsqueda visual y descubrimiento donde las personas encuentran inspiración, organizan ideas y compran productos, todo en un lugar positivo en línea.
 - [Awwwards](https://www.awwwards.com) - Premios al diseño, la creatividad y la innovación en internet, con un directorio de los mejores sitios web.
 - [Mobbin](https://mobbin.com) - 💵 Una biblioteca buscable de pantallas reales de apps móviles y web para inspiración de UI y UX.
+- [Cosmos](https://www.cosmos.so) - Un espacio de descubrimiento visual para reunir, organizar y compartir inspiración de diseño.
+- [Savee](https://savee.it) - Inspiración curada por diseñadores, con apps y extensiones de navegador para guardar referencias visuales.
+- [Typewolf](https://www.typewolf.com) - Las tendencias tipográficas: combinaciones de fuentes reales, lookbooks y recursos para aprender tipografía.
+- [One Page Love](https://onepagelove.com) - Una galería curada de sitios de una sola página, secciones y plantillas, seleccionados a mano desde 2008.

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,6 +40,10 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [React Bits](https://reactbits.dev) - Composants React animés, arrière-plans et effets de texte prêts à l'emploi, disponibles en variantes JS/TS et Tailwind/CSS.
 - [Base UI](https://base-ui.com) - Composants UI sans styles et accessibles pour créer des design systems, par les créateurs de Radix, Floating UI et Material UI.
 - [Park UI](https://park-ui.com) - Composants magnifiquement conçus, construits avec Ark UI et Panda CSS, compatibles avec React, Solid et Vue.
+- [Nuxt UI](https://ui.nuxt.com) - Une bibliothèque complète de composants Vue et Nuxt, avec plus de 125 composants accessibles stylés avec Tailwind CSS.
+- [Ark UI](https://ark-ui.com) - Une bibliothèque headless de plus de 45 composants accessibles pour React, Solid, Vue et Svelte, prête pour votre propre design system.
+- [Flowbite](https://flowbite.com) - Une bibliothèque open source de plus de 600 composants, sections et pages construits avec Tailwind CSS et conçus dans Figma.
+- [Once UI](https://once-ui.com) - Un design system open source pour les créateurs indépendants, avec plus de 100 composants et un thème géré depuis un seul fichier.
 
 ## Icônes
 
@@ -59,6 +63,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [SVGL](https://svgl.app) - Une bibliothèque de logos SVG de marques, prêts à copier, télécharger ou intégrer dans votre framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 Plus de 44k icônes SVG de qualité premium, régulièrement mises à jour pour UI, présentations et projets d'impression.
 - [Iconoir](https://iconoir.com) - Plus de 1600 icônes SVG gratuites et open source, disponibles en SVG, Font, React, React Native, Flutter, Figma et Framer.
+- [Font Awesome](https://fontawesome.com) - La bibliothèque d'icônes de référence du web, avec des milliers d'icônes en plusieurs styles, utilisables en webfont ou en SVG.
+- [OpenMoji](https://openmoji.org) - Des emojis open source pour les designers et les développeurs, disponibles en SVG, PNG et polices, en couleur ou en contour noir.
+- [Lineicons](https://lineicons.com) - Plus de 27 000 icônes gratuites et premium en plusieurs styles, avec fichiers Figma et paquets prêts pour les frameworks populaires.
 
 ## Illustrations
 
@@ -74,6 +81,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Shapefest](https://shapefest.com) - 💵 Plus de 100K images PNG transparentes de beaux objets 3D.
 - [Blush](https://blush.design) - Illustrations personnalisables gratuites avec Plugin Figma. Créez, éditez et utilisez des illustrations dans vos designs.
 - [Open Peeps](https://www.openpeeps.com) - Une bibliothèque d'illustrations dessinées à la main pour créer des scènes de personnes. Vous pouvez les utiliser dans l'illustration de produit, marketing, bandes dessinées et plus.
+- [Open Doodles](https://www.opendoodles.com) - Un ensemble gratuit d'illustrations dessinées à la main et open source, que vous pouvez recolorer, redimensionner et remixer.
+- [Ouch!](https://icons8.com/illustrations) - Illustrations vectorielles, 3D et animées signées Icons8, modifiables dans le navigateur et téléchargeables en SVG ou PNG.
 
 ## Modèles
 
@@ -81,6 +90,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modèles modernes et minimalistes pour construire votre prochain produit. Construits avec React, NextJS, TailwindCSS, Framer Motion et Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Créez facilement des pages d'atterrissage, tableaux de bord et modèles e-commerce.
 - [Preline](https://preline.co) - 💵 Une bibliothèque de composants Tailwind CSS open source pour tous les besoins. Livré avec des exemples et blocs UI, modèles, plugins, système de design Figma et plus.
+- [TailAdmin](https://tailadmin.com) - Un modèle de tableau de bord d'administration open source en Tailwind CSS pour HTML, React, Next.js, Vue, Angular et Laravel.
+- [Cruip](https://cruip.com) - 💵 Modèles de landing pages, de sites et de tableaux de bord en Tailwind CSS, codés en HTML, React, Next.js et Vue.
 
 ## Photographie
 
@@ -96,6 +107,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Nappy](https://nappy.co) - De belles photos haute résolution de personnes noires et métisses, gratuites pour un usage personnel et commercial.
 - [Deposit Photos](https://depositphotos.com) - 💵 Photos stock libres de droits, images vectorielles, vidéos et musique.
 - [Freepik](https://www.freepik.com) - 💵 Millions de vecteurs gratuits, fichiers PSD, photos et images générées par IA. Ressources premium pour vos projets créatifs.
+- [Kaboompics](https://kaboompics.com) - Photos libres de droits et séries photo sélectionnées pour un usage commercial, avec recherche par palette de couleurs.
 
 ## Polices
 
@@ -108,6 +120,9 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [T26](https://www.t26.com) - 💵 Achetez des polices bien conçues.
 - [Klim](https://klim.co.nz) - 💵 Achetez des polices de qualité, sélectionnées de fonderies de polices indépendantes.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 Une fonderie typographique indépendante aux caractères de haute qualité, gratuits à essayer avant l'achat de licence.
+- [Modern Font Stacks](https://modernfontstacks.com) - Des piles de polices système en CSS, classées par catégorie typographique, pour un rendu instantané sans téléchargement.
+- [Fontpair](https://www.fontpair.co) - Des associations de Google Fonts sélectionnées, avec un bac à sable pour tester typographie, couleurs et icônes ensemble.
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 Achetez des caractères encore en cours de création à prix réduit et recevez gratuitement toutes les mises à jour à venir.
 
 ## Couleurs
 
@@ -124,6 +139,8 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Happy Hues](https://www.happyhues.co) - Palettes de couleurs sélectionnées et présentées en contexte sur une vraie page, pour voir où va chaque couleur.
 - [Huemint](https://huemint.com) - Générateur de palettes de couleurs par apprentissage automatique pour marques, sites web et graphiques.
 - [OKLCH Color Picker](https://oklch.com) - Sélecteur et convertisseur de couleurs pour l'espace OKLCH, avec vérification du contraste et aperçu du gamut P3.
+- [Radix Colors](https://www.radix-ui.com/colors) - Un système de couleurs élégant et accessible pour les interfaces, avec des échelles à 12 niveaux et un mode sombre automatique.
+- [UI Colors](https://uicolors.app) - Générateur de couleurs Tailwind CSS qui prévisualise votre palette sur de vrais composants et exporte la configuration.
 
 ## Outils
 
@@ -144,12 +161,21 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Canva](https://www.canva.com) - 💵 Créez facilement des designs époustouflants avec la fonction glisser-déposer de Canva et des mises en page professionnelles.
 - [InVision](https://www.invisionapp.com) - 💵 Plateforme de design de produit numérique alimentant les meilleures expériences utilisateur du monde.
 - [Screen Studio](https://screen.studio) - 💵 Enregistreur d'écran macOS avec zoom automatique et animations fluides pour des démos produit soignées.
+- [Open Props](https://open-props.style) - Des variables CSS survitaminées : des design tokens soignés pour les couleurs, dégradés, ombres, courbes d'animation et plus.
+- [Hero Patterns](https://heropatterns.com) - Une collection de motifs de fond SVG répétables, personnalisables en couleur et en opacité.
+- [MagicPattern](https://www.magicpattern.design) - Plus de 30 générateurs de fonds, motifs, dégradés et autres graphismes, exportables en image, SVG ou CSS.
+- [Checklist Design](https://www.checklist.design) - Des recueils de bonnes pratiques pour sites, applications, composants et parcours, afin de vérifier chaque détail avant la mise en ligne.
+- [The Component Gallery](https://component.gallery) - Une référence de composants d'interface, avec de vrais exemples issus de dizaines de design systems publics.
 
 ## Livres
 
 - [The Book of Shaders](https://thebookofshaders.com) - Ceci est un guide doux étape par étape à travers l'univers abstrait et complexe des Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - Une collection de principes psychologiques à considérer lors de la conception d'interfaces utilisateur.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Donnez un aspect génial à vos idées, sans dépendre d'un designer.
+- [Practical Typography](https://practicaltypography.com) - Le livre de Matthew Butterick sur la typographie des documents et interfaces du quotidien, à lire gratuitement en ligne.
+- [Inclusive Components](https://inclusive-components.design) - Une bibliothèque de patterns sur la conception de composants d'interface accessibles et inclusifs, pièce par pièce.
+- [Every Layout](https://every-layout.dev) - 💵 Réapprenez la mise en page CSS grâce à un ensemble de primitives simples et composables.
+- [Growth.Design](https://growth.design) - Des études de cas produit racontées en bande dessinée, qui explorent la psychologie derrière les grandes expériences utilisateur.
 
 ## Communautés
 
@@ -159,3 +185,7 @@ Aussi disponible en : [English](README.md) | [中文](README.zh.md) | [Español]
 - [Pinterest](https://pinterest.com) - Une plateforme de recherche visuelle et découverte où les gens trouvent l'inspiration, organisent des idées et achètent des produits—tout dans un lieu positif en ligne.
 - [Awwwards](https://www.awwwards.com) - Récompenses du design, de la créativité et de l'innovation sur internet, avec un annuaire des meilleurs sites.
 - [Mobbin](https://mobbin.com) - 💵 Une bibliothèque consultable d'écrans réels d'applications mobiles et web pour l'inspiration UI et UX.
+- [Cosmos](https://www.cosmos.so) - Un espace de découverte visuelle pour collecter, organiser et partager son inspiration.
+- [Savee](https://savee.it) - De l'inspiration sélectionnée par des designers, avec applications et extensions de navigateur pour sauvegarder ses références visuelles.
+- [Typewolf](https://www.typewolf.com) - Les tendances typographiques : associations de polices réelles, lookbooks et ressources pour apprendre la typographie.
+- [One Page Love](https://onepagelove.com) - Une galerie sélectionnée de sites one page, de sections et de modèles, choisis à la main depuis 2008.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,10 @@
 - [React Bits](https://reactbits.dev) - プロジェクトにそのまま組み込めるアニメーション付き React コンポーネント、背景、テキストエフェクト。JS/TS と Tailwind/CSS の各バリアントを提供。
 - [Base UI](https://base-ui.com) - Radix、Floating UI、Material UI の開発チームによる、デザインシステム構築向けのアンスタイルでアクセシブルな UI コンポーネント。
 - [Park UI](https://park-ui.com) - Ark UI と Panda CSS で構築された美しいコンポーネント。React、Solid、Vue で利用可能。
+- [Nuxt UI](https://ui.nuxt.com) - Tailwind CSS でスタイリングされた 125 以上のアクセシブルなコンポーネントを備えた、Vue と Nuxt 向けの総合コンポーネントライブラリ。
+- [Ark UI](https://ark-ui.com) - React、Solid、Vue、Svelte 向けの 45 以上のアクセシブルなヘッドレスコンポーネント。独自のデザインシステム構築に最適。
+- [Flowbite](https://flowbite.com) - Tailwind CSS で構築され Figma でデザインされた 600 以上の UI コンポーネント・セクション・ページを揃えたオープンソースライブラリ。
+- [Once UI](https://once-ui.com) - インディークリエイター向けのオープンソースデザインシステム。100 以上のコンポーネントとテーマを 1 つのファイルで管理できる。
 
 ## アイコン
 
@@ -59,6 +63,9 @@
 - [SVGL](https://svgl.app) - ブランドの SVG ロゴとワードマークのライブラリ。コピー、ダウンロード、フレームワークへの取り込みに対応。
 - [Nucleoapp](https://nucleoapp.com) - 💵 UI、プレゼンテーション、印刷プロジェクト用に定期的に更新される 44k+のプレミアム品質 SVG アイコン。
 - [Iconoir](https://iconoir.com) - 1600以上の無料オープンソース SVG アイコン。SVG、Font、React、React Native、Flutter、Figma、Framer に対応。
+- [Font Awesome](https://fontawesome.com) - 複数のスタイルで数千のアイコンを提供する定番アイコンライブラリ。Web フォントとしても SVG としても利用できる。
+- [OpenMoji](https://openmoji.org) - デザイナーと開発者のためのオープンソース絵文字。カラーと黒線の 2 スタイルを SVG・PNG・フォント形式で提供。
+- [Lineicons](https://lineicons.com) - 複数スタイルの無料・有料アイコン 27,000 点以上。Figma ファイルと主要フレームワーク向けパッケージも用意。
 
 ## イラスト
 
@@ -74,6 +81,8 @@
 - [Shapefest](https://shapefest.com) - 💵 美しい 3D オブジェクトの 100K 以上の透明 PNG 画像。
 - [Blush](https://blush.design) - Figma プラグイン付きの無料カスタマイズ可能イラスト。デザインでイラストを作成、編集、使用できます。
 - [Open Peeps](https://www.openpeeps.com) - 人々のシーンを作成するための手描きイラストライブラリ。製品イラスト、マーケティング、コミックなどで使用できます。
+- [Open Doodles](https://www.opendoodles.com) - 自由に色替え・拡大縮小・改変ができる、無料でオープンソースの手描きイラスト集。
+- [Ouch!](https://icons8.com/illustrations) - Icons8 によるベクター・3D・アニメーションイラスト。ブラウザ上で編集し、SVG や PNG で書き出せる。
 
 ## テンプレート
 
@@ -81,6 +90,8 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 次の製品を構築するためのモダンでミニマリストなテンプレート。React、NextJS、TailwindCSS、Framer Motion、TypeScript で構築。
 - [Shuffle](https://shuffle.dev/) - 💵 ランディングページ、ダッシュボード、e コマーステンプレートを簡単に作成。
 - [Preline](https://preline.co) - 💵 あらゆるニーズに対応するオープンソース Tailwind CSS コンポーネントライブラリ。UI サンプル＆ブロック、テンプレート、プラグイン、Figma デザインシステムなどが付属。
+- [TailAdmin](https://tailadmin.com) - HTML・React・Next.js・Vue・Angular・Laravel に対応した、オープンソースの Tailwind CSS 管理ダッシュボードテンプレート。
+- [Cruip](https://cruip.com) - 💵 HTML・React・Next.js・Vue で実装された、Tailwind CSS のランディングページ／サイト／ダッシュボードテンプレート。
 
 ## 写真
 
@@ -96,6 +107,7 @@
 - [Nappy](https://nappy.co) - 黒人・褐色の肌の人々を撮影した高解像度の写真。個人利用・商用利用ともに無料。
 - [Deposit Photos](https://depositphotos.com) - 💵 ロイヤリティフリーストック写真、ベクター画像、動画、音楽。
 - [Freepik](https://www.freepik.com) - 💵 数百万の無料ベクター、PSD ファイル、写真、AI 生成画像。クリエイティブプロジェクト用のプレミアムリソース。
+- [Kaboompics](https://kaboompics.com) - 商用利用できる無料ストック写真とキュレーションされた撮影シリーズ。カラーパレットからも検索できる。
 
 ## フォント
 
@@ -108,6 +120,9 @@
 - [T26](https://www.t26.com) - 💵 よくデザインされたフォントを購入。
 - [Klim](https://klim.co.nz) - 💵 独立系フォント制作会社からの厳選品質フォントをショッピング。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 高品質な書体を手がける独立系フォントファウンドリ。ライセンス購入前に無料で試用可能。
+- [Modern Font Stacks](https://modernfontstacks.com) - 書体分類ごとに整理されたシステムフォントスタックの CSS。ダウンロード不要で即座に表示できる。
+- [Fontpair](https://www.fontpair.co) - 厳選された Google Fonts の組み合わせ集。書体・色・アイコンをまとめて試せるプレイグラウンド付き。
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 制作途中の書体を割安で購入でき、以後のアップデートをすべて無料で受け取れる。
 
 ## 色
 
@@ -124,6 +139,8 @@
 - [Happy Hues](https://www.happyhues.co) - 実際のページ上で文脈とともに見せてくれる厳選カラーパレット。それぞれの色の使いどころが一目でわかる。
 - [Huemint](https://huemint.com) - ブランド、ウェブサイト、グラフィック向けに機械学習でカラーパレットを生成。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色空間のカラーピッカー兼コンバーター。コントラストチェックと P3 色域プレビューに対応。
+- [Radix Colors](https://www.radix-ui.com/colors) - 12 段階のスケールと自動ダークモードを備えた、美しくアクセシブルな UI 向けカラーシステム。
+- [UI Colors](https://uicolors.app) - Tailwind CSS 用のカラー生成ツール。実際のコンポーネント上でパレットを確認し、設定を書き出せる。
 
 ## ツール
 
@@ -144,12 +161,21 @@
 - [Canva](https://www.canva.com) - 💵 Canva のドラッグ＆ドロップ機能とプロフェッショナルレイアウトで素晴らしいデザインを簡単に作成。
 - [InVision](https://www.invisionapp.com) - 💵 世界最高のユーザー体験を推進するデジタル製品デザインプラットフォーム。
 - [Screen Studio](https://screen.studio) - 💵 自動ズームと滑らかなアニメーションを備えた macOS 向け画面録画ツール。洗練された製品デモに最適。
+- [Open Props](https://open-props.style) - 強化された CSS 変数。色・グラデーション・シャドウ・イージングなどを丁寧に設計したデザイントークン集。
+- [Hero Patterns](https://heropatterns.com) - 色と不透明度をカスタマイズできる、繰り返し使える SVG 背景パターン集。
+- [MagicPattern](https://www.magicpattern.design) - 背景・パターン・グラデーションなどを作れる 30 以上のジェネレーター。画像・SVG・CSS で書き出せる。
+- [Checklist Design](https://www.checklist.design) - Web サイト・アプリ・コンポーネント・フローのベストプラクティス集。公開前に細部まで確認できる。
+- [The Component Gallery](https://component.gallery) - 数十の公開デザインシステムから集めた実例で構成された、UI コンポーネントのリファレンス。
 
 ## 書籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - これは、抽象的で複雑な Fragment Shaders の宇宙を通る優しいステップバイステップガイドです。
 - [Laws of UX](https://lawsofux.com) - ユーザーインターフェースを設計する際に参考になる心理学の原則集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 デザイナーに頼らずにアイデアを素晴らしく見せる。
+- [Practical Typography](https://practicaltypography.com) - 日常的な文書やインターフェースのためのタイポグラフィを説く Matthew Butterick の書籍。オンラインで無料で読める。
+- [Inclusive Components](https://inclusive-components.design) - アクセシブルでインクルーシブな UI コンポーネントを一つずつ設計する方法をまとめたパターンライブラリ。
+- [Every Layout](https://every-layout.dev) - 💵 シンプルで組み合わせ可能なレイアウトプリミティブを通じて CSS レイアウトを学び直す一冊。
+- [Growth.Design](https://growth.design) - 優れた UX の背後にある心理学を掘り下げる、マンガ形式のプロダクトケーススタディ。
 
 ## コミュニティ
 
@@ -159,3 +185,7 @@
 - [Pinterest](https://pinterest.com) - 人々がインスピレーションを見つけ、アイデアをキュレートし、製品を購入するビジュアル検索・発見プラットフォーム—すべてオンラインのポジティブな場所で。
 - [Awwwards](https://www.awwwards.com) - インターネット上のデザイン・創造性・革新性を表彰するアワード。優れたウェブサイトのディレクトリ付き。
 - [Mobbin](https://mobbin.com) - 💵 実際のモバイル・ウェブアプリの画面を検索できるライブラリ。UI・UX のインスピレーションに。
+- [Cosmos](https://www.cosmos.so) - デザインのインスピレーションを集め、整理し、共有するためのビジュアル探索スペース。
+- [Savee](https://savee.it) - デザイナーがキュレーションしたインスピレーション集。アプリやブラウザ拡張でビジュアル参照を保存できる。
+- [Typewolf](https://www.typewolf.com) - タイポグラフィのトレンド情報。実例のフォントの組み合わせやルックブック、学習リソースを紹介。
+- [One Page Love](https://onepagelove.com) - 2008 年から手作業で選び続けている、1 ページサイト・セクション・テンプレートのギャラリー。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [React Bits](https://reactbits.dev) - Animated React components, backgrounds and text effects you can drop into a project, available in JS/TS and Tailwind/CSS variants.
 - [Base UI](https://base-ui.com) - Unstyled, accessible UI components for building design systems, from the creators of Radix, Floating UI and Material UI.
 - [Park UI](https://park-ui.com) - Beautifully designed components built with Ark UI and Panda CSS that work with React, Solid and Vue.
+- [Nuxt UI](https://ui.nuxt.com) - A comprehensive Vue and Nuxt component library with 125+ accessible components styled with Tailwind CSS.
+- [Ark UI](https://ark-ui.com) - A headless library of 45+ accessible components for React, Solid, Vue and Svelte, ready for your own design system.
+- [Flowbite](https://flowbite.com) - An open-source library of 600+ UI components, sections and pages built with Tailwind CSS and designed in Figma.
+- [Once UI](https://once-ui.com) - An open-source design system for indie creators, with 100+ components and theming managed from a single file.
 
 ## Icons
 
@@ -59,6 +63,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [SVGL](https://svgl.app) - A library of brand SVG logos and wordmarks, ready to copy, download or pull into your framework.
 - [Nucleoapp](https://nucleoapp.com) - 💵 44k+ premium-quality SVG icons, regularly updated for UIs, presentations, and print projects.
 - [Iconoir](https://iconoir.com) - 1,600+ free, open-source, high-quality SVG icons available for SVG, Font, React, React Native, Flutter, Figma, and Framer.
+- [Font Awesome](https://fontawesome.com) - The internet's icon library and toolkit, with thousands of icons across multiple styles, usable as web fonts or SVG.
+- [OpenMoji](https://openmoji.org) - Open-source emojis for designers and developers, available as SVG, PNG and fonts in color and black outline styles.
+- [Lineicons](https://lineicons.com) - 27,000+ free and premium icons in multiple styles, with Figma files and ready-made packages for popular frameworks.
 
 ## Illustrations
 
@@ -74,6 +81,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Shapefest](https://shapefest.com) - 💵 100K+ transparent PNG images of beautiful 3D objects .
 - [Blush](https://blush.design) - Free customizable illustrations with Figma Plugin. Create, edit, and use illustrations in your designs.
 - [Open Peeps](https://www.openpeeps.com) - A hand-drawn illustration library to create scenes of people. You can use them in product illustration, marketing, comics, and more.
+- [Open Doodles](https://www.opendoodles.com) - A free set of open-source hand-drawn illustrations you can recolor, resize and remix.
+- [Ouch!](https://icons8.com/illustrations) - Vector, 3D and animated illustrations by Icons8, editable in the browser and downloadable as SVG or PNG.
 
 ## Templates
 
@@ -81,6 +90,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 Modern and minimalist templates for building your next product. Built with React, NextJS, TailwindCSS, Framer Motion and Typescript.
 - [Shuffle](https://shuffle.dev/) - 💵 Easily create landing pages, dashboards, and e-commerce templates.
 - [Preline](https://preline.co) - 💵 An open-source Tailwind CSS components library for any needs. Comes with UI examples & blocks, templates, plugins, Figma design system and more.
+- [TailAdmin](https://tailadmin.com) - An open-source Tailwind CSS admin dashboard template for HTML, React, Next.js, Vue, Angular and Laravel.
+- [Cruip](https://cruip.com) - 💵 Tailwind CSS landing page, website and dashboard templates coded in HTML, React, Next.js and Vue.
 
 ## Photography
 
@@ -96,6 +107,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Nappy](https://nappy.co) - Beautiful high-resolution photos of Black and Brown people, free for personal and commercial use.
 - [Deposit Photos](https://depositphotos.com) - 💵 Royalty-free Stock Photos, Vector Images, Videos and Music.
 - [Freepik](https://www.freepik.com) - 💵 Millions of free vectors, PSD files, photos and AI-generated images. Premium resources for your creative projects.
+- [Kaboompics](https://kaboompics.com) - Free stock photos and curated photoshoots for commercial use, searchable by color palette.
 
 ## Fonts
 
@@ -108,6 +120,9 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [T26](https://www.t26.com) - 💵 Purchase well-designed fonts.
 - [Klim](https://klim.co.nz) - 💵 Shop quality, curated fonts from indie font foundries.
 - [Pangram Pangram](https://pangrampangram.com) - 💵 An independent type foundry with high-quality typefaces, free to try before you license them.
+- [Modern Font Stacks](https://modernfontstacks.com) - System font stack CSS organized by typeface classification, for instant rendering with no downloads.
+- [Fontpair](https://www.fontpair.co) - Curated Google Font combinations with a playground to test type, colors and icons together.
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 Buy typefaces while they are still in progress at a lower price, and get every future update for free.
 
 ## Colors
 
@@ -124,6 +139,8 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Happy Hues](https://www.happyhues.co) - Curated color palettes shown in context on a real page, so you can see where each color belongs.
 - [Huemint](https://huemint.com) - Machine-learning color palette generator for brands, websites and graphics.
 - [OKLCH Color Picker](https://oklch.com) - Color picker and converter for the OKLCH color space, with contrast checking and P3 gamut preview.
+- [Radix Colors](https://www.radix-ui.com/colors) - A gorgeous, accessible color system for user interfaces, with 12-step scales and automatic dark mode.
+- [UI Colors](https://uicolors.app) - Tailwind CSS color generator that previews your palette on real components and exports the config.
 
 ## Tools
 
@@ -144,12 +161,21 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Canva](https://www.canva.com) - 💵 Create stunning designs easily with Canva's drag-and-drop feature and professional layouts.
 - [InVision](https://www.invisionapp.com) - 💵 Digital product design platform powering the world's best user experiences.
 - [Screen Studio](https://screen.studio) - 💵 macOS screen recorder with automatic zoom and smooth animations for polished product demos.
+- [Open Props](https://open-props.style) - Supercharged CSS variables: expertly crafted design tokens for colors, gradients, shadows, easings and more.
+- [Hero Patterns](https://heropatterns.com) - A collection of repeatable SVG background patterns, customizable in color and opacity.
+- [MagicPattern](https://www.magicpattern.design) - 30+ generators for backgrounds, patterns, gradients and other graphics, exportable as images, SVG or CSS.
+- [Checklist Design](https://www.checklist.design) - Collections of best practices for websites, apps, components and flows, so you can check every detail before shipping.
+- [The Component Gallery](https://component.gallery) - A reference of interface components with real examples drawn from dozens of public design systems.
 
 ## Books
 
 - [The Book of Shaders](https://thebookofshaders.com) - This is a gentle step-by-step guide through the abstract and complex universe of Fragment Shaders.
 - [Laws of UX](https://lawsofux.com) - A collection of psychology principles designers can consider when building user interfaces.
 - [Refactoring UI](https://www.refactoringui.com) - 💵 Make your ideas look awesome, without relying on a designer.
+- [Practical Typography](https://practicaltypography.com) - Matthew Butterick's book on typography for everyday documents and interfaces, free to read online.
+- [Inclusive Components](https://inclusive-components.design) - A pattern library about designing accessible, inclusive interface components piece by piece.
+- [Every Layout](https://every-layout.dev) - 💵 Relearn CSS layout through a set of simple, composable layout primitives.
+- [Growth.Design](https://growth.design) - Product case studies told as comics, digging into the psychology behind great user experiences.
 
 ## Communities
 
@@ -159,3 +185,7 @@ Also available in: [中文](README.zh.md) | [Español](README.es.md) | [Françai
 - [Pinterest](https://pinterest.com) - A visual search and discovery platform where people find inspiration, curate ideas and shop products—all in a positive place online.
 - [Awwwards](https://www.awwwards.com) - Awards for design, creativity and innovation on the internet, with a directory of the best websites.
 - [Mobbin](https://mobbin.com) - 💵 A searchable library of real mobile and web app screens for UI and UX inspiration.
+- [Cosmos](https://www.cosmos.so) - A visual discovery space to collect, organize and share design inspiration.
+- [Savee](https://savee.it) - Inspiration curated by designers, with apps and browser extensions for saving visual references.
+- [Typewolf](https://www.typewolf.com) - What's trending in type: real-world font pairings, lookbooks and typography learning resources.
+- [One Page Love](https://onepagelove.com) - A curated gallery of one page websites, sections and templates, hand-picked since 2008.

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,6 +40,10 @@
 - [React Bits](https://reactbits.dev) - 可直接放进项目的 React 动效组件、背景与文字特效，提供 JS/TS 与 Tailwind/CSS 多种版本。
 - [Base UI](https://base-ui.com) - 由 Radix、Floating UI 和 Material UI 团队打造的无样式、可访问 UI 组件，适合构建设计系统。
 - [Park UI](https://park-ui.com) - 基于 Ark UI 和 Panda CSS 构建的精美组件，支持 React、Solid 和 Vue。
+- [Nuxt UI](https://ui.nuxt.com) - 全面的 Vue 与 Nuxt 组件库，提供 125+ 个无障碍组件，使用 Tailwind CSS 精心设计。
+- [Ark UI](https://ark-ui.com) - 面向 React、Solid、Vue 和 Svelte 的无头组件库，包含 45+ 个无障碍组件，可直接用于自建设计系统。
+- [Flowbite](https://flowbite.com) - 开源 UI 库，提供 600+ 个基于 Tailwind CSS 的组件、区块与页面，并配有 Figma 设计稿。
+- [Once UI](https://once-ui.com) - 面向独立创作者的开源设计系统，提供 100+ 个组件，主题与样式集中在单个文件中管理。
 
 ## 图标
 
@@ -60,6 +64,9 @@
 
 - [React Icons](https://react-icons.github.io/react-icons/) - 使用 react-icons 轻松在 React 项目中包含流行图标。
 - [Iconoir](https://iconoir.com) - 1600+ 免费开源的高质量 SVG 图标，支持 SVG、Font、React、React Native、Flutter、Figma 和 Framer。
+- [Font Awesome](https://fontawesome.com) - 互联网上最知名的图标库与工具集，涵盖数千个多种风格的图标，可作为 Web 字体或 SVG 使用。
+- [OpenMoji](https://openmoji.org) - 面向设计师和开发者的开源 emoji，提供彩色与黑白线条两种风格的 SVG、PNG 和字体格式。
+- [Lineicons](https://lineicons.com) - 27000+ 个免费与付费图标，涵盖多种风格，并提供 Figma 源文件和主流框架的现成安装包。
 
 ## 插图
 
@@ -75,6 +82,8 @@
 - [Shapefest](https://shapefest.com) - 💵 100K+ 透明 PNG 图像的美丽 3D 对象。
 - [Blush](https://blush.design) - 免费可定制插图，带 Figma 插件。在您的设计中创建、编辑和使用插图。
 - [Open Peeps](https://www.openpeeps.com) - 手绘人物插图库，用于创建人物场景。可用于产品插图、营销、漫画等。
+- [Open Doodles](https://www.opendoodles.com) - 免费开源的手绘插画合集，可自由改色、缩放与二次创作。
+- [Ouch!](https://icons8.com/illustrations) - Icons8 出品的矢量、3D 与动画插画，可在浏览器中编辑，并导出为 SVG 或 PNG。
 
 ## 模板
 
@@ -82,6 +91,8 @@
 - [Aceternity Template](https://pro.aceternity.com/templates) - 💵 现代和极简的模板，用于构建您的下一个产品。使用 React、NextJS、TailwindCSS、Framer Motion 和 Typescript 构建。
 - [Shuffle](https://shuffle.dev/) - 💵 轻松创建登陆页面、仪表板和电子商务模板。
 - [Preline](https://preline.co) - 💵 一个开源的 Tailwind CSS 组件库，适用于各种需求。提供 UI 示例和区块、模板、插件、Figma 设计系统等。
+- [TailAdmin](https://tailadmin.com) - 开源的 Tailwind CSS 后台仪表盘模板，支持 HTML、React、Next.js、Vue、Angular 和 Laravel。
+- [Cruip](https://cruip.com) - 💵 基于 Tailwind CSS 的落地页、网站与仪表盘模板，提供 HTML、React、Next.js 和 Vue 版本。
 
 ## 摄影
 
@@ -97,6 +108,7 @@
 - [Nappy](https://nappy.co) - 以黑人和棕色人种为主题的高分辨率精美照片，可免费用于个人和商业项目。
 - [Deposit Photos](https://depositphotos.com) - 💵 免费版权库存照片、矢量图像、视频和音乐。
 - [Freepik](https://www.freepik.com) - 💵 数百万免费矢量、PSD 文件、照片和 AI 生成图像。创意项目的优质资源。
+- [Kaboompics](https://kaboompics.com) - 可免费商用的图库照片与成套拍摄合集，支持按配色搜索。
 
 ## 字体
 
@@ -109,6 +121,9 @@
 - [T26](https://www.t26.com) - 💵 购买设计精美的字体。
 - [Klim](https://klim.co.nz) - 💵 购买优质、精选的字体，来自独立字体铸造厂。
 - [Pangram Pangram](https://pangrampangram.com) - 💵 独立字体工作室出品的高品质字体，购买授权前可免费试用。
+- [Modern Font Stacks](https://modernfontstacks.com) - 按字体分类整理的系统字体栈 CSS，无需下载即可即时渲染。
+- [Fontpair](https://www.fontpair.co) - 精选的 Google Fonts 字体搭配，并提供可同时试验字体、配色与图标的演练场。
+- [Future Fonts](https://www.futurefonts.xyz) - 💵 在字体尚未完工时以更低价格购买，并免费获得后续所有更新。
 
 ## 颜色
 
@@ -125,6 +140,8 @@
 - [Happy Hues](https://www.happyhues.co) - 在真实页面场景中展示的精选配色方案，让你直观看到每种颜色的用法。
 - [Huemint](https://huemint.com) - 使用机器学习为品牌、网站和图形生成配色方案。
 - [OKLCH Color Picker](https://oklch.com) - OKLCH 色彩空间的取色器与转换工具，支持对比度检查和 P3 色域预览。
+- [Radix Colors](https://www.radix-ui.com/colors) - 为界面打造的精美且无障碍的色彩系统，提供 12 级色阶与自动暗色模式。
+- [UI Colors](https://uicolors.app) - Tailwind CSS 配色生成器，可在真实组件上预览调色板并导出配置。
 
 ## 工具
 
@@ -145,12 +162,21 @@
 - [Canva](https://www.canva.com) - 💵 使用 Canva 的拖放功能和专业布局轻松创建令人惊叹的设计。
 - [InVision](https://www.invisionapp.com) - 💵 为世界最佳用户体验提供支持的数字产品设计平台。
 - [Screen Studio](https://screen.studio) - 💵 macOS 屏幕录制工具，自动缩放和流畅动画，适合制作精致的产品演示。
+- [Open Props](https://open-props.style) - 强化版 CSS 变量：精心打磨的设计令牌，涵盖颜色、渐变、阴影、缓动等。
+- [Hero Patterns](https://heropatterns.com) - 可重复平铺的 SVG 背景图案合集，颜色与透明度均可自定义。
+- [MagicPattern](https://www.magicpattern.design) - 30+ 款背景、图案、渐变等图形生成器，可导出为图片、SVG 或 CSS。
+- [Checklist Design](https://www.checklist.design) - 面向网站、应用、组件与流程的最佳实践清单，帮助你在上线前逐项核对细节。
+- [The Component Gallery](https://component.gallery) - 界面组件参考库，收录来自数十个公开设计系统的真实示例。
 
 ## 书籍
 
 - [The Book of Shaders](https://thebookofshaders.com) - 这是一本温和的分步指南，带您进入片段着色器的抽象和复杂的宇宙。
 - [Laws of UX](https://lawsofux.com) - 设计师在构建用户界面时可以参考的心理学原则合集。
 - [Refactoring UI](https://www.refactoringui.com) - 💵 让您的想法看起来很棒，而无需依赖设计师。
+- [Practical Typography](https://practicaltypography.com) - Matthew Butterick 撰写的排版书籍，面向日常文档与界面，可在线免费阅读。
+- [Inclusive Components](https://inclusive-components.design) - 关于如何逐个打造可访问、包容性界面组件的模式库。
+- [Every Layout](https://every-layout.dev) - 💵 通过一组简单可组合的布局原语，重新学习 CSS 布局。
+- [Growth.Design](https://growth.design) - 以漫画形式呈现的产品案例研究，深入剖析优秀用户体验背后的心理学。
 
 ## 社区
 
@@ -160,3 +186,7 @@
 - [Pinterest](https://pinterest.com) - 一个视觉搜索和发现平台，人们可以在网上找到灵感、策划想法和购物产品。
 - [Awwwards](https://www.awwwards.com) - 表彰互联网上的设计、创意与创新，并收录最佳网站目录。
 - [Mobbin](https://mobbin.com) - 💵 可搜索的真实移动端和网页应用界面截图库，提供 UI 与 UX 灵感。
+- [Cosmos](https://www.cosmos.so) - 视觉发现空间，用于收集、整理并分享设计灵感。
+- [Savee](https://savee.it) - 由设计师精选的灵感库，配有客户端与浏览器扩展，方便随手收藏视觉参考。
+- [Typewolf](https://www.typewolf.com) - 字体潮流风向标：真实网站的字体搭配、案例合辑与排版学习资源。
+- [One Page Love](https://onepagelove.com) - 自 2008 年起人工精选的单页网站、区块与模板画廊。


### PR DESCRIPTION
## What

Adds 30 new design resources to every category, synchronized across all six language READMEs (English, 中文, Español, Français, Deutsch, 日本語).

| Category | Additions |
| --- | --- |
| UI Libraries | Nuxt UI, Ark UI, Flowbite, Once UI |
| Icons | Font Awesome, OpenMoji, Lineicons |
| Illustrations | Open Doodles, Ouch! |
| Templates | TailAdmin, Cruip 💵 |
| Photography | Kaboompics |
| Fonts | Modern Font Stacks, Fontpair, Future Fonts 💵 |
| Colors | Radix Colors, UI Colors |
| Tools | Open Props, Hero Patterns, MagicPattern, Checklist Design, The Component Gallery |
| Books | Practical Typography, Inclusive Components, Every Layout 💵, Growth.Design |
| Communities | Cosmos, Savee, Typewolf, One Page Love |

## How each candidate was vetted

Rather than trusting link-roundup articles, every candidate site was loaded in a headless Chromium at 1280×820 and the rendered screenshot was reviewed before deciding. Candidates were rejected on visual and content grounds, including:

- **Glaze (glazestock.com)** — domain now serves unrelated gambling spam.
- **Reshot** — homepage announces the service is retiring.
- **IRA Design** — origin down (Cloudflare 522).
- **Gratisography, picjumbo** — usable, but the pages are dominated by stock-photo affiliate banners.
- **Leonardo, Iconify** — solid tools, but the landing pages are plain enough to fall short of the list's bar.
- **Landingfolio, Layers** — cluttered with overlays and ads; broken media on the feed.
- **Excalidraw, Pika** — good products, but redundant with tldraw / Shots / ray.so already on the list.

## Validation

`npx markdown-link-check README.md` → 157 links checked, all 30 new links pass.

The 9 reported failures are all pre-existing entries that block automated requests (Unsplash 401, Pexels/Pixabay/Freepik/Canva 403, Cult UI 429, brandcolors.net 202, vectorCraftr timeout) and are untouched by this PR. A few of the new entries (Once UI, OpenMoji, Icons8, Kaboompics, Checklist Design) also refuse plain `curl`, but all returned HTTP 200 and rendered correctly in the browser check.

Formatting follows the existing convention — `- [Name](URL) - Description.` with 💵 marking paid resources — and entries are appended to the end of their category in each file, matching how previous batches were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbaKFStYnuEiuQ4VM2SmgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbaKFStYnuEiuQ4VM2SmgG)_